### PR TITLE
哆啦A梦被拆了...

### DIFF
--- a/vendors/pangu.js
+++ b/vendors/pangu.js
@@ -57,6 +57,9 @@
         text = text.replace(/([\u4e00-\u9fa5\u3040-\u30FF])(\"|\'(\S+))/ig, '$1 $2');
         text = text.replace(/((\S+)\'|\")([\u4e00-\u9fa5\u3040-\u30FF])/ig, '$1 $3'); // $2 是 (\S+)
 
+        // “哆啦A梦”
+        text = text.replace(/([\u54c6\u591a])([\u5566\u62c9])(?:\s)([Aa\uff21])(?:\s)([\u68a6\u5922])/ig, '$1$2$3$4');
+
         return text;
     }
 


### PR DESCRIPTION
这个名字是音译而来，“A”被当作一个字来用，两边加上半角空格看起来怪怪的。
我印象中唯一一次例外是用作序数词，哆啦拿着手偶说「你好，我叫哆啦 B 梦！」（GTV 版，短篇动画）

修改前：`哆啦 A 梦 wiki`
修改后：`哆啦A梦 wiki`

也可以考虑换成比较窄的空格（`U+2002` - `U+200B`），放在 `$3` 两侧。
