### PR TITLE
Fix document about usage of ES module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Learn more on [npm](https://www.npmjs.com/package/pangu).
 
 ```js
 var pangu = require('pangu'); // ES5
-import pangu from 'pangu'; // ES6
+import * as pangu from 'pangu'; // ES6
 
 pangu.spacing('Sephiroth見他這等神情,也是悚然一驚:不知我這Ultimate Destructive Magic是否對付得了?');
 // output: Sephiroth 見他這等神情, 也是悚然一驚: 不知我這 Ultimate Destructive Magic 是否對付得了?


### PR DESCRIPTION
Reason: `import pangu from 'pangu'` means to import the default export, but the library doesn't have a default export like `export default pangu;` or `module.exports.default = pangu;`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export