### PR TITLE
執行 spacing 函數前先判斷輸入值是否為字符串類型

### DIFF
--- a/src/shared/core.js
+++ b/src/shared/core.js
@@ -46,6 +46,13 @@ const ansCJK = /([A-Za-z0-9`~\$%\^&\*\-=\+\\\|/!;:,\.\?\u00a1-\u00ff\u2022\u2026
 class Pangu {
 
   spacing(text) {
+    if (typeof text !== 'string') {
+      if (text) {
+        console.warn(`Warning: pangu.js 可接收的參數類型為 string ，但是收到的參數類型為 ${typeof text}`);
+      }
+      return '';
+    }
+    
     let newText = text;
 
     newText = newText.replace(cjkQuote, '$1 $2');


### PR DESCRIPTION
如果不進行參數校驗，當輸入的數據不為字符串類型時，會因為 `replace` 方法不可用導致頁面報錯，可能會阻塞 JavaScript 繼續執行， 所以增加了一個參數校驗判斷一下輸入的值是否為字符串類型再繼續執行操作。