### PR TITLE
Update min node version to 4 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.12"
   - "4"
-  - "5"
   - "6"
+  - "8"
+  - "10"
 
 before_script:
   - npm install -g codecov


### PR DESCRIPTION
0.12 is too old, it makes more sense to support LTS versions