### PR TITLE
Rename spacing methods from gerund to verb form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - 網頁裡的 `<sup>` 元素也一樣，跟前面的文字之間不加空格，空格只加在 `<sup>` 後面
   - `℃`、`℉`、`№` 這類 Letterlike Symbols 區段的字元碰到中文時會加空格；`™`、`℠`、`®` 跟上標字元一樣黏在前面的文字上
   - `©` 後面緊接著數字時會加空格：`版權所有©2026` 會變成 `版權所有 © 2026`
+- 所有 `spacingXxx()` 方法改名為 `spaceXxx()`：`spaceText()`、`spaceFile()`、`spaceFileSync()`、`spacePage()`、`spaceNode()`、`autoSpacePage()`、`stopAutoSpacePage()`，型別 `AutoSpacingPageConfig` 也改名為 `AutoSpacePageConfig`
 - 修正動態填入內容的元素（例如原本是空的 `<span>` 後來才由 JavaScript 塞進數字）跟旁邊已經加過空格的文字之間會漏加空格的問題
 
 ### 為什麼你們就是不能加個空格呢？

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - `℃`、`℉`、`№` 這類 Letterlike Symbols 區段的字元碰到中文時會加空格；`™`、`℠`、`®` 跟上標字元一樣黏在前面的文字上
   - `©` 後面緊接著數字時會加空格：`版權所有©2026` 會變成 `版權所有 © 2026`
 - 修正動態填入內容的元素（例如原本是空的 `<span>` 後來才由 JavaScript 塞進數字）跟旁邊已經加過空格的文字之間會漏加空格的問題
-- 所有 `spacingXxx()` 方法改名為 `spaceXxx()`
+- 所有 `spacingXxx()` methods 改名為 `spaceXxx()`
   - `spacingText()` -> `spaceText()`
   - `spacingFile()` -> `spaceFile()`
   - `spacingFileSync()` -> `spaceFileSync()`
@@ -22,7 +22,6 @@
   - `spacingNode()` -> `spaceNode()`
   - `autoSpacingPage()` -> `autoSpacePage()`
   - `stopAutoSpacingPage()` -> `stopAutoSpacePage()`
-  - `AutoSpacingPageConfig` -> `AutoSpacePageConfig`
 
 ### 為什麼你們就是不能加個空格呢？
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,16 @@
     - 網頁裡的 `<sup>` 元素也一樣，跟前面的文字之間不加空格，空格只加在 `<sup>` 後面
   - `℃`、`℉`、`№` 這類 Letterlike Symbols 區段的字元碰到中文時會加空格；`™`、`℠`、`®` 跟上標字元一樣黏在前面的文字上
   - `©` 後面緊接著數字時會加空格：`版權所有©2026` 會變成 `版權所有 © 2026`
-- 所有 `spacingXxx()` 方法改名為 `spaceXxx()`：`spaceText()`、`spaceFile()`、`spaceFileSync()`、`spacePage()`、`spaceNode()`、`autoSpacePage()`、`stopAutoSpacePage()`，型別 `AutoSpacingPageConfig` 也改名為 `AutoSpacePageConfig`
 - 修正動態填入內容的元素（例如原本是空的 `<span>` 後來才由 JavaScript 塞進數字）跟旁邊已經加過空格的文字之間會漏加空格的問題
+- 所有 `spacingXxx()` 方法改名為 `spaceXxx()`
+  - `spacingText()` -> `spaceText()`
+  - `spacingFile()` -> `spaceFile()`
+  - `spacingFileSync()` -> `spaceFileSync()`
+  - `spacingPage()` -> `spacePage()`
+  - `spacingNode()` -> `spaceNode()`
+  - `autoSpacingPage()` -> `autoSpacePage()`
+  - `stopAutoSpacingPage()` -> `stopAutoSpacePage()`
+  - `AutoSpacingPageConfig` -> `AutoSpacePageConfig`
 
 ### 為什麼你們就是不能加個空格呢？
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,7 +6,7 @@ pangu.js inserts whitespace between CJK and ANS characters automatically. It shi
 
 **Space**:
 The verb for inserting whitespace: pangu spaces CJK from ANS, and respaces a text node that a page re-render undid. Spaced and unspaced are the adjectives, and tight describes a shape that stays unspaced on purpose (`A/B`). Spacing is the noun and the modifier: spacing rules, boundary spacing. A space is also the character itself, and it counts: a pangu element holds one space. Public method names take the verb (`spaceText()`, `spacePage()`); a predicate about the concept keeps the noun (`hasProperSpacing()`).
-_Avoid_: spacings (no plural), space out, spaced out, spacer, spacious
+_Avoid_: spacings (no plural)
 
 **CJK**:
 The class of Chinese, Japanese, and Korean characters. Every spacing rule depends on this class.
@@ -16,11 +16,9 @@ Alphabetical letters, numerical digits, and symbols. When an ANS character is ad
 
 **Text spacing**:
 Inserting whitespace between CJK and ANS characters inside one string. On a page that string is one text node's data; for the string API it is the whole input.
-_Avoid_: paranoid spacing
 
 **Boundary spacing**:
 Deciding whether whitespace goes between two adjacent text nodes on a page, and where it goes. `CJK<b>A</b>` gets the space at the start of the `A` node. `CJK<a>A</a>` gets the space at the end of the `CJK` node, because a link, underline, or strike-through would render a space that is added inside it. `<a>A</a><a>CJK</a>` gets a pangu element between the links. In three cases, nothing is added: whitespace or a block edge already separates the nodes, an ignored tag such as `<code>` sits between them, or one node is hidden.
-_Avoid_: pair spacing, adjacent-node spacing
 
 **Decision**:
 What the rules choose for one text node or one boundary before pangu writes anything. A boundary spacing decision says where the space goes: nowhere, at the start of the next text node, at the end of the current one, or in a pangu element between them. A text node decision says what the node needs first: trim its leading space, prepend a space, or apply text spacing. A decision is computed from facts alone, with no DOM access, so it runs in vitest. The classifier never makes a decision; it answers with a label.
@@ -28,23 +26,20 @@ _Avoid_: verdict
 
 **Settle**:
 A text node settles when nothing will rewrite it again in this batch. Text spacing runs first, then boundary spacing rewrites tails of nodes it already visited, so a node is spaced before it is settled. Pangu hands settled nodes to the host at the batch tail, never per node.
-_Avoid_: finished, done, final
+_Avoid_: finished, final, done
 
 **Pangu element**:
 An inline `<pangu>` element that holds one space. Pangu inserts it between two text nodes that both sit in a link, underline, or strike-through, because a space that is added inside either node would render as part of that node (`<a>A</a><pangu> </pangu><a>CJK</a>`). Pangu never inserts it inside a grid or flex container, because there the element would become a layout item.
-_Avoid_: space element, marker element
 
 **Native text-autospace**:
 The gap that the browser renders between CJK and ANS letters or digits through the `text-autospace` CSS property. It is visual only: no character is inserted. The gap is narrower than a real space. The gap ignores symbols. The browser suppresses the gap wherever a real space already exists. So native text-autospace combines with text spacing and boundary spacing without adding a second gap.
-_Avoid_: native autospacing, text autospace, CSS spacing, autospace mode, text-autospace (bare, in prose)
 
 **Late fix**:
 A correction to the rules output. It is applied after the rules run, and something other than the rules decides it, such as a fixed list or a classifier. A late fix only inserts or removes spaces. It never rewrites the author's characters. A late fix goes through the same scheduling path as text spacing, never as a separate write, so on a hidden page it waits with everything else. While a text node still holds a late fix, text spacing leaves it alone and only boundary spacing touches it; a page re-render of that node hands it back to the rules.
-_Avoid_: un-insert (in prose), model fix
 
 **Page re-render**:
 The page writes its own data over a text node that pangu already spaced. The page does this in one of two ways: it sets the `Text` node's data again, or it removes the node and inserts a fresh one. For example, the page has `CJKA`. Pangu spaces it to `CJK A`. Then the page writes `CJKA` into the same node again, or replaces the node with one that holds `CJKA`. The page did not intend to remove the space. It only rendered its own data again, and its data never had the space. From pangu's view, the write undid its work. Common causes: a second render pass in React or Vue, a script that sets `textContent` from a variable, or a live region that refreshes on a timer. Pangu detects a page re-render by comparing the new data against the last data that pangu wrote to that node. Pangu then re-spaces the node inside the observer callback, before the browser paints. If the subtree is too large to re-space before paint, the node queues like other dynamic content.
-_Avoid_: revert, external rewrite, overwrite
+_Avoid_: revert
 
 ## Chrome Extension
 
@@ -68,7 +63,6 @@ A symbol between two ANS characters binds them into a joiner token, and the symb
 
 **Joiner token**:
 ANS characters that any symbol joins tight (`A/B`, `26/30`, `vinta/hal-9000`, `S&P`, `Q&A`, `A+B`, `5+5`, `foo=bar&baz=1`, `A<B`, `HSIAO-MING`). A joiner token is never split. It is spaced from adjacent CJK as one unit. Slashes, pipes, and plus signs also follow slash reading, pipe reading, and plus reading.
-_Avoid_: slash token, slash operand pair, &-token
 
 **Slash reading**:
 Decided per line, never across lines. A slash with ANS characters on both sides forms a joiner token. If a line has only one slash and that slash is in direct contact with CJK, the slash acts as an operator. If a line has repeated slashes, they read as a file path or a list and stay unspaced.
@@ -99,32 +93,26 @@ Tags are protected from spacing rules. Text inside attributes is processed. The 
 
 **Tag mention**:
 A bare tag with no attributes, a non-void name, and no closing counterpart anywhere in the text. It can be self-closing or not (`CJK <div> CJK`, `CJK List<String> CJK`, `CJK <Spinner /> CJK`). A tag mention reads as one unit that is mentioned in prose, not as markup: it is spaced where it is in direct contact with CJK, and tight against ANS characters. Paired tags, void elements (`<br>`, `<br />`), and tags with attributes stay protected markup.
-_Avoid_: tag-in-prose, prose tag
 
 ### AI Spacing
 
 **AI spacing**:
 The extension's second stage, on by default with a toggle to turn it off. It resolves candidates with a fixed list or a classifier and applies corrections as late fixes. If the model cannot answer, candidates that need it keep the rules output.
-_Avoid_: model layer
 
 **Symbol sense disambiguation**:
 Deciding which reading a symbol carries from the context around it, not from the symbol alone. It is the natural language processing (NLP) task of the same name. Slash, pipe, plus, and affix reading do it with heuristics. AI spacing does it with a fixed list or a classifier. Use this term to relate pangu to outside work. Name the specific reading when you describe the algorithm.
-_Avoid_: symbol WSD, symbol disambiguation
 
 **Ambiguous shape**:
 A shape where the rules cannot derive the symbol's reading, so a fixed list or a classifier decides it. It defines what to flag and which late fix to apply, with labels only when a model is needed.
-_Avoid_: symbol class, ambiguity, shape (bare, for this sense)
 
 **Candidate**:
 One occurrence of an ambiguous shape, flagged on the text before spacing. It carries the sentence around it and the symbol's position in that sentence, which is all the classifier reads. On a page, the sentence is the inline text around the symbol as a reader sees it: it continues across inline elements, ends at a block edge, a `<br>`, or sentence-ending punctuation, steps past hidden and ignored elements, `<sup>`, and `<sub>`, and treats a newline the way the browser renders it.
-_Avoid_: span, ambiguous span, model span
 
 **Settled candidate**:
 A candidate bound to the text node it came from, with the symbol's index in the settled text, so a late fix edits only bytes the batch settled on.
 
 **Classifier**:
 The component that reads one candidate and answers with one label from a fixed menu. It never answers with text, so it can never rewrite an author's characters.
-_Avoid_: LLM, AI (for the component)
 
 **Label**:
 The classifier's answer for one candidate. It is one of the fixed menu for its ambiguous shape.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,10 @@ _Avoid_: paranoid spacing
 Deciding whether whitespace goes between two adjacent text nodes on a page, and where it goes. `CJK<b>A</b>` gets the space at the start of the `A` node. `CJK<a>A</a>` gets the space at the end of the `CJK` node, because a link, underline, or strike-through would render a space that is added inside it. `<a>A</a><a>CJK</a>` gets a pangu element between the links. In three cases, nothing is added: whitespace or a block edge already separates the nodes, an ignored tag such as `<code>` sits between them, or one node is hidden.
 _Avoid_: pair spacing, adjacent-node spacing
 
+**Decision**:
+What the rules choose for one text node or one boundary before pangu writes anything. A boundary spacing decision says where the space goes: nowhere, at the start of the next text node, at the end of the current one, or in a pangu element between them. A text node decision says what the node needs first: trim its leading space, prepend a space, or apply text spacing. A decision is computed from facts alone, with no DOM access, so it runs in vitest. The classifier never makes a decision; it answers with a label.
+_Avoid_: verdict
+
 **Settle**:
 A text node settles when nothing will rewrite it again in this batch. Text spacing runs first, then boundary spacing rewrites tails of nodes it already visited, so a node is spaced before it is settled. Pangu hands settled nodes to the host at the batch tail, never per node.
 _Avoid_: finished, done, final

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ pangu.js inserts whitespace between CJK and ANS characters automatically. It shi
 ## Language
 
 **Space**:
-The verb for inserting whitespace: pangu spaces CJK from ANS, and respaces a text node that a page re-render undid. Spaced and unspaced are the adjectives, and tight describes a shape that stays unspaced on purpose (`A/B`). Spacing is the noun and the modifier: spacing rules, boundary spacing. A space is also the character itself, and it counts: a pangu element holds one space. Public method names keep an older spacing prefix (`spacingText()`, `spacingPage()`), and those stay as they are.
+The verb for inserting whitespace: pangu spaces CJK from ANS, and respaces a text node that a page re-render undid. Spaced and unspaced are the adjectives, and tight describes a shape that stays unspaced on purpose (`A/B`). Spacing is the noun and the modifier: spacing rules, boundary spacing. A space is also the character itself, and it counts: a pangu element holds one space. Public method names take the verb (`spaceText()`, `spacePage()`); a predicate about the concept keeps the noun (`hasProperSpacing()`).
 _Avoid_: spacings (no plural), space out, spaced out, spacer, spacious
 
 **CJK**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,4 +124,4 @@ _Avoid_: LLM, AI (for the component)
 
 **Label**:
 The classifier's answer for one candidate. It is one of the fixed menu for its ambiguous shape.
-_Avoid_: verdict (the rules' word), answer
+_Avoid_: decision (the rules' word), answer

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,4 +124,4 @@ _Avoid_: LLM, AI (for the component)
 
 **Label**:
 The classifier's answer for one candidate. It is one of the fixed menu for its ambiguous shape.
-_Avoid_: decision (the rules' word), answer
+_Avoid_: decision (the rules' word)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const text = pangu.spaceText('與PM戰鬥的人，應當小心自己不要成為
 const content = await pangu.spaceFile('/path/to/text.txt');
 ```
 
-You **SHOULD NOT** use `pangu.js` to spacing Markdown documents, this library is specially designed for HTML webpages and plain texts without any markup language. See [issue #127](https://github.com/vinta/pangu.js/issues/127).
+You **SHOULD NOT** use `pangu.js` to space Markdown documents, this library is specially designed for HTML webpages and plain texts without any markup language. See [issue #127](https://github.com/vinta/pangu.js/issues/127).
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ Learn more in the [changelog](CHANGELOG.md) or on [npm](https://www.npmjs.com/pa
 
 ### Browser
 
-**Make sure to import from `pangu/browser`** in ESM, which is the DOM-aware build (`spacingNode()`, `autoSpacingPage()`) with matching TypeScript types and resolves correctly across all bundlers.
+**Make sure to import from `pangu/browser`** in ESM, which is the DOM-aware build (`spaceNode()`, `autoSpacePage()`) with matching TypeScript types and resolves correctly across all bundlers.
 
 ```js
 import pangu from 'pangu/browser';
 // or
 // <script src="https://cdn.jsdelivr.net/npm/pangu@latest/dist/browser/pangu.umd.js"></script>
 
-const text = pangu.spacingText('當你凝視著bug，bug也凝視著你');
+const text = pangu.spaceText('當你凝視著bug，bug也凝視著你');
 // text = '當你凝視著 bug，bug 也凝視著你'
 
-pangu.spacingNode(document.getElementById('main'));
-document.querySelectorAll('.comment').forEach((el) => pangu.spacingNode(el));
-document.querySelectorAll('p').forEach((el) => pangu.spacingNode(el));
+pangu.spaceNode(document.getElementById('main'));
+document.querySelectorAll('.comment').forEach((el) => pangu.spaceNode(el));
+document.querySelectorAll('p').forEach((el) => pangu.spaceNode(el));
 
 // Listen to any DOM change and automatically perform spacing via MutationObserver()
-document.addEventListener('DOMContentLoaded', () => pangu.autoSpacingPage());
+document.addEventListener('DOMContentLoaded', () => pangu.autoSpacePage());
 ```
 
 Also on:
@@ -89,10 +89,10 @@ import pangu from 'pangu';
 // or
 // const pangu = require('pangu');
 
-const text = pangu.spacingText('與PM戰鬥的人，應當小心自己不要成為PM');
+const text = pangu.spaceText('與PM戰鬥的人，應當小心自己不要成為PM');
 // text = '與 PM 戰鬥的人，應當小心自己不要成為 PM'
 
-const content = await pangu.spacingFile('/path/to/text.txt');
+const content = await pangu.spaceFile('/path/to/text.txt');
 ```
 
 You **SHOULD NOT** use `pangu.js` to spacing Markdown documents, this library is specially designed for HTML webpages and plain texts without any markup language. See [issue #127](https://github.com/vinta/pangu.js/issues/127).

--- a/browser-extensions/chrome/src/content-script.ts
+++ b/browser-extensions/chrome/src/content-script.ts
@@ -8,7 +8,7 @@ function startAutoSpacing(settings: Settings) {
   if (settings.is_ai_spacing_enabled) {
     warmUpAiSpacing();
   }
-  pangu.autoSpacingPage();
+  pangu.autoSpacePage();
 }
 
 // Content script registration only applies at page load, so the navigation listener must check the URL policy when the URL changes as well
@@ -16,7 +16,7 @@ function applyAutoSpacingUrlPolicy(settings: Settings) {
   if (shouldAutoSpacing(settings, location.href)) {
     startAutoSpacing(settings);
   } else {
-    pangu.stopAutoSpacingPage();
+    pangu.stopAutoSpacePage();
   }
 }
 

--- a/browser-extensions/chrome/src/content-script.ts
+++ b/browser-extensions/chrome/src/content-script.ts
@@ -2,7 +2,7 @@ import pangu from '../../../src/browser/pangu';
 import { applyAiSpacing, warmUpAiSpacing } from './ai-spacing/content-script';
 import type { ContentScriptResponse, MessageToContentScript } from './messages';
 import { getSettings, type Settings } from './settings/storage';
-import { shouldAutoSpacing } from './settings/urls';
+import { shouldAutoSpace } from './settings/urls';
 
 function startAutoSpacing(settings: Settings) {
   if (settings.is_ai_spacing_enabled) {
@@ -13,7 +13,7 @@ function startAutoSpacing(settings: Settings) {
 
 // Content script registration only applies at page load, so the navigation listener must check the URL policy when the URL changes as well
 function applyAutoSpacingUrlPolicy(settings: Settings) {
-  if (shouldAutoSpacing(settings, location.href)) {
+  if (shouldAutoSpace(settings, location.href)) {
     startAutoSpacing(settings);
   } else {
     pangu.stopAutoSpacePage();

--- a/browser-extensions/chrome/src/settings/urls.ts
+++ b/browser-extensions/chrome/src/settings/urls.ts
@@ -44,7 +44,7 @@ function isUrlExcludedByFilter(settings: Settings, url: string) {
   return settings.filter_mode === 'whitelist';
 }
 
-export function shouldAutoSpacing(settings: Settings, url: string) {
+export function shouldAutoSpace(settings: Settings, url: string) {
   return settings.spacing_mode === 'spacing_when_load' && !isUrlExcludedByFilter(settings, url);
 }
 

--- a/docs/adr/0020-site-filters-follow-same-document-navigation.md
+++ b/docs/adr/0020-site-filters-follow-same-document-navigation.md
@@ -4,7 +4,7 @@ The DOM content script used to carry the blacklist as `excludeMatches` (or the w
 
 The decisions:
 
-1. **In automatic mode, the DOM script registers on every http(s) page and applies the filters itself.** `shouldAutoSpacing()` runs at load and when `currententrychange` reports a different URL. Same-URL history updates preserve manual activation. On an excluded page the script is present but idle until the user clicks the manual button.
+1. **In automatic mode, the DOM script registers on every http(s) page and applies the filters itself.** `shouldAutoSpace()` runs at load and when `currententrychange` reports a different URL. Same-URL history updates preserve manual activation. On an excluded page the script is present but idle until the user clicks the manual button.
 2. **The Navigation API is the change signal.** It fires in the isolated world for push, replace, and traverse, with `location.href` already updated, and needs no permission. `webNavigation` would add a "Read your browsing history" warning, which disables a published extension until each user re-approves. Patching `history.pushState` needs a MAIN-world script plus a bridge, because an isolated-world patch never sees the page's calls. `popstate` and `hashchange` do not fire on `pushState`. The Chrome floor moves from 99 to 102 for it.
 3. **One matcher.** The popup status row, the icon, and the content script all decide through `URLPattern` now. Registration no longer carries user patterns, so the concern in [ADR 0008](0008-text-autospace-default-on-ignores-filters.md) about a rejected pattern taking down a batched registration no longer applies.
 

--- a/examples/test-browser.html
+++ b/examples/test-browser.html
@@ -64,7 +64,7 @@
         <h2>Auto-spacing Entire Page</h2>
         <p>這段文字包含English和中文mixed在一起，還有numbers123。</p>
         <p>pangu.js會自動在CJK字元和half-width characters之間加入空白。</p>
-        <button onclick="autoSpacingPage()">Run</button>
+        <button onclick="autoSpacePage()">Run</button>
     </div>
 
     <div id="result"></div>
@@ -75,13 +75,13 @@
         function spacingDemo1() {
             const elem = document.getElementById('demo1');
             const original = elem.textContent;
-            pangu.spacingNode(elem);
+            pangu.spaceNode(elem);
             const result = document.getElementById('result');
             result.textContent = `UMD Version Result:\nOriginal: ${original}\nProcessed: ${elem.textContent}`;
         }
 
-        function autoSpacingPage() {
-            pangu.autoSpacingPage();
+        function autoSpacePage() {
+            pangu.autoSpacePage();
             document.getElementById('result').textContent = 'Auto-spacing enabled! Try editing the text on the page.';
         }
     </script>
@@ -93,7 +93,7 @@
         document.getElementById('esmButton').addEventListener('click', () => {
             const elem = document.getElementById('demo2');
             const original = elem.textContent;
-            const spaced = pangu.spacingText(original);
+            const spaced = pangu.spaceText(original);
             elem.textContent = spaced;
 
             const result = document.getElementById('result');

--- a/examples/test-browser.js
+++ b/examples/test-browser.js
@@ -37,21 +37,21 @@ function startServer() {
 
     await page.goto(PAGE_URL, { waitUntil: 'networkidle' });
 
-    // spacingNode() and autoSpacingPage() schedule their DOM writes, so wait for the text instead of reading it right after the click
+    // spaceNode() and autoSpacePage() schedule their DOM writes, so wait for the text instead of reading it right after the click
     const expectText = (selector, text) => page.waitForFunction(([s, t]) => document.querySelector(s).textContent === t, [selector, text], { timeout: 5000 });
     const runButton = (heading) => page.locator('.example', { hasText: heading }).getByRole('button');
 
     await runButton('UMD Version').click();
     await expectText('#demo1', '測試文字：當你凝視著 bug，bug 也凝視著你');
-    console.log('UMD <script> tag: spacingNode() works');
+    console.log('UMD <script> tag: spaceNode() works');
 
     await runButton('ESM Version').click();
     await expectText('#demo2', '另一個測試：使用 JavaScript 開發 Web 應用程式');
-    console.log('ESM module import: spacingText() works');
+    console.log('ESM module import: spaceText() works');
 
     await runButton('Auto-spacing Entire Page').click();
     await page.waitForFunction(() => document.body.innerText.includes('這段文字包含 English 和中文 mixed 在一起'), null, { timeout: 5000 });
-    console.log('autoSpacingPage() works');
+    console.log('autoSpacePage() works');
 
     assert.deepEqual(problems, []);
     console.log('No page errors, console errors, or failed requests');

--- a/examples/test-commonjs.js
+++ b/examples/test-commonjs.js
@@ -10,7 +10,7 @@ const { NodePangu, pangu: namedPangu } = require('pangu');
 console.log('=== Testing CommonJS Imports ===\n');
 
 // Test default export
-assert.equal(typeof pangu.spacingText, 'function');
+assert.equal(typeof pangu.spaceText, 'function');
 console.log('Default require works');
 
 // NodePangu is attached to the instance for CommonJS ergonomics
@@ -28,13 +28,13 @@ console.log('Named pangu and interop default both point at the instance');
 
 // Test functionality
 const text = '測試CommonJS模組';
-const spaced = pangu.spacingText(text);
+const spaced = pangu.spaceText(text);
 assert.equal(spaced, '測試 CommonJS 模組');
 console.log(`\nTest spacing: "${text}" → "${spaced}"`);
 
 // Test instance creation
 const customPangu = new NodePangu();
-assert.equal(customPangu.spacingText('測試test'), '測試 test');
+assert.equal(customPangu.spaceText('測試test'), '測試 test');
 console.log('Custom instance works');
 
 // Test that pangu is the instance itself
@@ -53,10 +53,10 @@ console.log('require("pangu/package.json") resolves');
 // rejects, and Node exits non-zero on an unhandled rejection, so the IIFE still fails the suite
 const filePath = join(tmpdir(), 'pangu-example-commonjs.txt');
 (async () => {
-  await writeFile(filePath, '測試spacingFile方法');
+  await writeFile(filePath, '測試spaceFile方法');
   try {
-    assert.equal(await pangu.spacingFile(filePath), '測試 spacingFile 方法');
-    console.log('\nspacingFile() works');
+    assert.equal(await pangu.spaceFile(filePath), '測試 spaceFile 方法');
+    console.log('\nspaceFile() works');
   } finally {
     await unlink(filePath);
   }

--- a/examples/test-esm.mjs
+++ b/examples/test-esm.mjs
@@ -12,7 +12,7 @@ import browserPangu, { BrowserPangu, pangu as namedBrowserPangu } from 'pangu/br
 console.log('=== Testing ESM Imports ===\n');
 
 // Test default export
-assert.equal(typeof pangu.spacingText, 'function');
+assert.equal(typeof pangu.spaceText, 'function');
 console.log('Default import works');
 
 // In ESM, use the named import (NodePangu is not attached to the instance)
@@ -31,13 +31,13 @@ console.log('Namespace import exposes default, pangu, and NodePangu');
 
 // Test functionality
 const text = '測試ESM模組';
-const spaced = pangu.spacingText(text);
+const spaced = pangu.spaceText(text);
 assert.equal(spaced, '測試 ESM 模組');
 console.log(`\nTest spacing: "${text}" → "${spaced}"`);
 
 // Test instance creation
 const customPangu = new NodePangu();
-assert.equal(customPangu.spacingText('測試test'), '測試 test');
+assert.equal(customPangu.spaceText('測試test'), '測試 test');
 console.log('Custom instance works');
 
 // Test that pangu is the instance itself
@@ -46,10 +46,10 @@ console.log('\nVerifying pangu is an instance');
 
 // Test async file spacing
 const filePath = join(tmpdir(), 'pangu-example-esm.txt');
-await writeFile(filePath, '測試spacingFile方法');
+await writeFile(filePath, '測試spaceFile方法');
 try {
-  assert.equal(await pangu.spacingFile(filePath), '測試 spacingFile 方法');
-  console.log('spacingFile() works');
+  assert.equal(await pangu.spaceFile(filePath), '測試 spaceFile 方法');
+  console.log('spaceFile() works');
 } finally {
   await unlink(filePath);
 }
@@ -57,7 +57,7 @@ try {
 // The ./browser subpath has the same three-face surface, and its text engine works anywhere
 assert.equal(namedBrowserPangu, browserPangu);
 assert.ok(browserPangu instanceof BrowserPangu);
-assert.equal(browserPangu.spacingText('測試test'), '測試 test');
+assert.equal(browserPangu.spaceText('測試test'), '測試 test');
 console.log('\npangu/browser default, named pangu, and BrowserPangu work');
 
 console.log('\nESM imports working correctly!');

--- a/examples/test-types.mts
+++ b/examples/test-types.mts
@@ -4,29 +4,29 @@
 // verbatim, so a relative import written without a file extension ships as-is and fails to resolve for any consumer on moduleResolution node16/nodenext. This file is checked the way such a consumer
 // resolves the package, so that class of bug fails here instead of reaching npm.
 import panguNode, { NodePangu, pangu as namedPanguNode } from 'pangu';
-import panguBrowser, { BrowserPangu, pangu as namedPanguBrowser, type AutoSpacingPageConfig } from 'pangu/browser';
+import panguBrowser, { BrowserPangu, pangu as namedPanguBrowser, type AutoSpacePageConfig } from 'pangu/browser';
 
 // Members inherited from the shared Pangu base class. These are the ones that disappear when dist/node/index.d.ts cannot resolve its '../shared/index.js' import, because NodePangu then extends an error type
-export const spaced: string = panguNode.spacingText('當你凝視著bug');
+export const spaced: string = panguNode.spaceText('當你凝視著bug');
 export const isProper: boolean = panguNode.hasProperSpacing('當你凝視著 bug');
 export const version: string = panguNode.version;
 
 // Members declared directly on NodePangu
-export const fileSpaced: Promise<string> = panguNode.spacingFile('example.txt');
-export const fileSpacedSync: string = panguNode.spacingFileSync('example.txt');
+export const fileSpaced: Promise<string> = panguNode.spaceFile('example.txt');
+export const fileSpacedSync: string = panguNode.spaceFileSync('example.txt');
 
 // The named exports must stay constructible and keep the inherited surface
 export const nodeInstance: NodePangu = new NodePangu();
-export const nodeInstanceSpaced: string = nodeInstance.spacingText('當你凝視著bug');
+export const nodeInstanceSpaced: string = nodeInstance.spaceText('當你凝視著bug');
 
 // The named `pangu` exports carry the same instance types as the defaults on both entries
 export const namedNodeInstance: NodePangu = namedPanguNode;
 
 // The ./browser subpath export resolves its own declaration chain, so it needs the same coverage
 export const browserInstance: BrowserPangu = new BrowserPangu();
-export const browserSpaced: string = browserInstance.spacingText('當你凝視著bug');
-export const browserDefaultSpaced: string = panguBrowser.spacingText('當你凝視著bug');
+export const browserSpaced: string = browserInstance.spaceText('當你凝視著bug');
+export const browserDefaultSpaced: string = panguBrowser.spaceText('當你凝視著bug');
 export const namedBrowserInstance: BrowserPangu = namedPanguBrowser;
 
-// The config interface is public API for autoSpacingPage() callers, so its exported shape is pinned here
-export const config: AutoSpacingPageConfig = { pageDelayMs: 100, nodeDelayMs: 50, nodeMaxWaitMs: 200 };
+// The config interface is public API for autoSpacePage() callers, so its exported shape is pinned here
+export const config: AutoSpacePageConfig = { pageDelayMs: 100, nodeDelayMs: 50, nodeMaxWaitMs: 200 };

--- a/examples/test-types.ts
+++ b/examples/test-types.ts
@@ -7,20 +7,20 @@
 import panguNode, { NodePangu, pangu as namedPangu } from 'pangu';
 
 // Members inherited from the shared Pangu base class. These are the ones that disappear when dist/node/index.d.ts cannot resolve its '../shared/index.js' import, because NodePangu then extends an error type
-export const spaced: string = panguNode.spacingText('當你凝視著bug');
+export const spaced: string = panguNode.spaceText('當你凝視著bug');
 export const isProper: boolean = panguNode.hasProperSpacing('當你凝視著 bug');
 export const version: string = panguNode.version;
 
 // Members declared directly on NodePangu
-export const fileSpaced: Promise<string> = panguNode.spacingFile('example.txt');
-export const fileSpacedSync: string = panguNode.spacingFileSync('example.txt');
+export const fileSpaced: Promise<string> = panguNode.spaceFile('example.txt');
+export const fileSpacedSync: string = panguNode.spaceFileSync('example.txt');
 
 // The named exports must stay constructible and keep the inherited surface. The CJS entry is `export =` an instance, so NodePangu arrives as a value only and InstanceType is how a require() consumer names
 // the type; test-types.mts covers the class-as-type spelling that the ESM declarations support
 export const nodeInstance: InstanceType<typeof NodePangu> = new NodePangu();
-export const nodeInstanceSpaced: string = nodeInstance.spacingText('當你凝視著bug');
+export const nodeInstanceSpaced: string = nodeInstance.spaceText('當你凝視著bug');
 
 // The .d.cts declares the named `pangu` export and the interop `default` property, and both must surface the full instance type so destructuring require() consumers keep the same API as everyone else
 export const namedInstance: InstanceType<typeof NodePangu> = namedPangu;
-export const namedInstanceSpaced: string = namedPangu.spacingText('當你凝視著bug');
+export const namedInstanceSpaced: string = namedPangu.spaceText('當你凝視著bug');
 export const defaultProperty: InstanceType<typeof NodePangu> = panguNode.default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
         "@playwright/test": "1.61.1",
-        "@types/chrome": "0.2.2",
+        "@types/chrome": "0.2.9",
         "@types/dom-chromium-ai": "0.0.17",
         "@types/node": "20.19.43",
         "eslint": "10.7.0",
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.2.tgz",
-      "integrity": "sha512-8rSMZ4cvo2xmaSyQg0sN5yRL7oiDkntLoiHxUhfwQnv1mvnkrdoZ25SlNrKWmYKaeP50WvrfWj1pmc02+U9KKw==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.9.tgz",
+      "integrity": "sha512-6rXrDPkkWv4D2Q23HqT+iED4voODU5CpOSc2VFgKyecSFItuEsIBvz9CY6jUQ3dd+Q7zo1bnCE9pKRMtkYut5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",
     "@playwright/test": "1.61.1",
-    "@types/chrome": "0.2.2",
+    "@types/chrome": "0.2.9",
     "@types/dom-chromium-ai": "0.0.17",
     "@types/node": "20.19.43",
     "eslint": "10.7.0",

--- a/src/browser/boundary-spacing.ts
+++ b/src/browser/boundary-spacing.ts
@@ -3,10 +3,10 @@ import { ANY_CJK, pangu } from '../shared/index.js';
 const QUOTE = /["\u201c\u201d]/;
 
 // Where the space goes at the boundary between two adjacent text nodes
-export type BoundarySpacingVerdict = 'none' | 'prepend-next' | 'append-current' | 'insert-element';
+export type BoundarySpacingDecision = 'none' | 'prepend-next' | 'append-current' | 'insert-element';
 
 // What a single text node needs before its boundaries are considered
-export type TextNodeSpacingVerdict = 'trim-leading-space' | 'prepend-space' | 'apply-text-spacing';
+export type TextNodeSpacingDecision = 'trim-leading-space' | 'prepend-space' | 'apply-text-spacing';
 
 export interface BoundarySpacingContext {
   // Up to three trailing characters of the current text node, not just the last
@@ -100,24 +100,24 @@ export function decideBoundarySpacing(boundarySpacingContext: BoundarySpacingCon
 }
 
 export function decideTextNodeSpacing(textNodeSpacingContext: TextNodeSpacingContext) {
-  const textNodeSpacingVerdicts: TextNodeSpacingVerdict[] = [];
+  const textNodeSpacingDecisions: TextNodeSpacingDecision[] = [];
 
   // The standalone quote rule reads the text left by the trim rule
   let { text } = textNodeSpacingContext;
   if (text.startsWith(' ') && textNodeSpacingContext.hiddenBoundaryBefore()) {
-    textNodeSpacingVerdicts.push('trim-leading-space');
+    textNodeSpacingDecisions.push('trim-leading-space');
     text = text.substring(1);
   }
 
   if (isStandaloneQuote(text)) {
     if (textNodeSpacingContext.previousElementLastChar !== null && ANY_CJK.test(textNodeSpacingContext.previousElementLastChar)) {
-      textNodeSpacingVerdicts.push('prepend-space');
+      textNodeSpacingDecisions.push('prepend-space');
     }
   } else {
-    textNodeSpacingVerdicts.push('apply-text-spacing');
+    textNodeSpacingDecisions.push('apply-text-spacing');
   }
 
-  return textNodeSpacingVerdicts;
+  return textNodeSpacingDecisions;
 }
 
 // spaceJunction is pure and a page repeats the same few junction windows at
@@ -149,7 +149,7 @@ function needsBoundarySpace(currentTail: string, nextFirst: string) {
 }
 
 // The junction reading can put a second space inside the tail itself: CJK/ + CJK reads CJK / CJK, because the slash rule needs both sides of the slash in view. Returns the tail with its interior
-// spaces written in, or null when the tail already reads right. Only meaningful when the boundary verdict is a spacing action; on 'none' the tail must stay untouched
+// spaces written in, or null when the tail already reads right. Only meaningful when the boundary decision is a spacing action; on 'none' the tail must stay untouched
 export function respaceCurrentTail(currentTail: string, nextFirst: string) {
   const spacedJunction = spaceJunction(currentTail, nextFirst);
   if (!spacedJunction.endsWith(` ${nextFirst}`)) {

--- a/src/browser/boundary-spacing.ts
+++ b/src/browser/boundary-spacing.ts
@@ -133,7 +133,7 @@ function spaceJunction(currentTail: string, nextFirst: string) {
     return cached;
   }
 
-  const spacedJunction = pangu.spacingText(junction);
+  const spacedJunction = pangu.spaceText(junction);
 
   if (spacedJunctionCache.size >= SPACED_JUNCTION_CACHE_MAX) {
     spacedJunctionCache.clear();
@@ -143,7 +143,7 @@ function spaceJunction(currentTail: string, nextFirst: string) {
 }
 
 function needsBoundarySpace(currentTail: string, nextFirst: string) {
-  // Only a space right at the junction counts: a space that spacingText puts
+  // Only a space right at the junction counts: a space that spaceText puts
   // anywhere else belongs inside the tail, not at the boundary
   return spaceJunction(currentTail, nextFirst).endsWith(` ${nextFirst}`) && !isQuoteNextToCjk(currentTail.slice(-1), nextFirst);
 }

--- a/src/browser/dom/visibility-detector.ts
+++ b/src/browser/dom/visibility-detector.ts
@@ -1,11 +1,11 @@
 export class VisibilityDetector {
-  // Verdicts repeat heavily within one spacing batch: every boundary re-checks
+  // Answers repeat heavily within one spacing batch: every boundary re-checks
   // the same ancestor chain (p → body → html). Scoped to a batch via clearCache()
   // because page styles can change between batches
-  private verdictCache = new WeakMap<Element, boolean>();
+  private cache = new WeakMap<Element, boolean>();
 
   public clearCache() {
-    this.verdictCache = new WeakMap();
+    this.cache = new WeakMap();
   }
 
   public isElementVisuallyHidden(element: Element) {
@@ -100,12 +100,12 @@ export class VisibilityDetector {
   }
 
   private isElementVisuallyHiddenCached(element: Element) {
-    const cached = this.verdictCache.get(element);
+    const cached = this.cache.get(element);
     if (cached !== undefined) {
       return cached;
     }
-    const verdict = this.isElementVisuallyHidden(element);
-    this.verdictCache.set(element, verdict);
-    return verdict;
+    const hidden = this.isElementVisuallyHidden(element);
+    this.cache.set(element, hidden);
+    return hidden;
   }
 }

--- a/src/browser/pangu.ts
+++ b/src/browser/pangu.ts
@@ -4,7 +4,7 @@ import { DomWalker } from './dom/dom-walker.js';
 import { VisibilityDetector } from './dom/visibility-detector.js';
 import { TaskScheduler } from './scheduling/task-scheduler.js';
 
-export interface AutoSpacingPageConfig {
+export interface AutoSpacePageConfig {
   pageDelayMs?: number;
   nodeDelayMs?: number;
   nodeMaxWaitMs?: number;
@@ -71,8 +71,8 @@ export class BrowserPangu extends Pangu {
   // Pre-paint re-space stays bounded: subtrees with more text nodes than this fall back to the queue
   private static readonly maxSyncTextNodes = 256;
 
-  private isAutoSpacingPageExecuted = false;
-  private autoSpacingPageObserver: MutationObserver | null = null;
+  private isAutoSpacePageExecuted = false;
+  private autoSpacePageObserver: MutationObserver | null = null;
 
   // Last data we wrote per text node: distinguishes pangu's own mutation records
   // (data still equals the entry, drop them) from page re-renders of spaced content
@@ -85,59 +85,59 @@ export class BrowserPangu extends Pangu {
   public readonly taskScheduler = new TaskScheduler();
   public readonly visibilityDetector = new VisibilityDetector();
 
-  // A callback called after spacingTextNodes() settles a batch of text nodes, carrying each node's text before/after spacing
+  // A callback called after spaceTextNodes() settles a batch of text nodes, carrying each node's text before/after spacing
   // The Chrome extension's AI spacing uses it to apply late fixes from LLM
   public onTextNodesSettled: ((settledTextNodes: SettledTextNode[]) => void) | null = null;
 
   // PUBLIC
 
-  public autoSpacingPage({ pageDelayMs = 1000, nodeDelayMs = 500, nodeMaxWaitMs = 2000 }: AutoSpacingPageConfig = {}) {
+  public autoSpacePage({ pageDelayMs = 1000, nodeDelayMs = 500, nodeMaxWaitMs = 2000 }: AutoSpacePageConfig = {}) {
     if (!(document.body instanceof Node)) {
       return;
     }
 
-    if (this.isAutoSpacingPageExecuted) {
+    if (this.isAutoSpacePageExecuted) {
       return;
     }
 
-    this.isAutoSpacingPageExecuted = true;
-    const observer = this.setupAutoSpacingPageObserver(nodeDelayMs, nodeMaxWaitMs);
+    this.isAutoSpacePageExecuted = true;
+    const observer = this.setupAutoSpacePageObserver(nodeDelayMs, nodeMaxWaitMs);
 
-    // Skipped once stopAutoSpacingPage() dropped this observer before the delay elapsed
+    // Skipped once stopAutoSpacePage() dropped this observer before the delay elapsed
     this.waitForVideosToLoad(
       pageDelayMs,
       once(() => {
-        if (this.autoSpacingPageObserver === observer) {
-          this.spacingPage();
+        if (this.autoSpacePageObserver === observer) {
+          this.spacePage();
         }
       }),
     );
   }
 
-  public spacingPage() {
+  public spacePage() {
     // Page title
     const title = document.querySelector('head > title');
     if (title) {
-      this.spacingNode(title);
+      this.spaceNode(title);
     }
 
     // Page body
-    this.spacingNode(document.body);
+    this.spaceNode(document.body);
   }
 
-  public spacingNode(contextNode: Node) {
+  public spaceNode(contextNode: Node) {
     // Only process nodes with actual content (excluding text nodes that contain only whitespace)
     const textNodes = DomWalker.collectTextNodes(contextNode, true);
-    this.schedule(() => this.spacingTextNodes(textNodes));
+    this.schedule(() => this.spaceTextNodes(textNodes));
   }
 
-  public stopAutoSpacingPage() {
-    if (this.autoSpacingPageObserver) {
-      this.autoSpacingPageObserver.disconnect();
-      this.autoSpacingPageObserver = null;
+  public stopAutoSpacePage() {
+    if (this.autoSpacePageObserver) {
+      this.autoSpacePageObserver.disconnect();
+      this.autoSpacePageObserver = null;
     }
 
-    this.isAutoSpacingPageExecuted = false;
+    this.isAutoSpacePageExecuted = false;
   }
 
   public applyLateFixes(lateFixes: readonly LateFix[]) {
@@ -169,7 +169,7 @@ export class BrowserPangu extends Pangu {
     return display === 'grid' || display === 'inline-grid' || display === 'flex' || display === 'inline-flex';
   }
 
-  private spacingTextNodes(textNodes: Node[]) {
+  private spaceTextNodes(textNodes: Node[]) {
     // Visibility verdicts are memoized per batch; styles may change between batches
     this.visibilityDetector.clearCache();
 
@@ -307,7 +307,7 @@ export class BrowserPangu extends Pangu {
           if (this.onTextNodesSettled) {
             unsettledTextNodes.push({ node: textNode, unspaced: textNode.data });
           }
-          const newText = this.spacingText(textNode.data);
+          const newText = this.spaceText(textNode.data);
           if (textNode.data !== newText) {
             textNode.data = newText;
             this.lastWrittenData.set(textNode, textNode.data);
@@ -321,12 +321,12 @@ export class BrowserPangu extends Pangu {
   // Same processing as the queued paths, but synchronous, for pre-paint re-spacing
   // inside the MutationObserver callback. Returns false when the subtree exceeds
   // maxTextNodes, so the caller can fall back to the debounced queue
-  private spacingNodeSync(contextNode: Node, maxTextNodes: number) {
+  private spaceNodeSync(contextNode: Node, maxTextNodes: number) {
     const textNodes = DomWalker.collectTextNodes(contextNode);
     if (textNodes.length > maxTextNodes) {
       return false;
     }
-    this.spacingTextNodes(this.withNeighborTextNodes(textNodes).reverse());
+    this.spaceTextNodes(this.withNeighborTextNodes(textNodes).reverse());
     return true;
   }
 
@@ -497,24 +497,24 @@ export class BrowserPangu extends Pangu {
     }
   }
 
-  private setupAutoSpacingPageObserver(nodeDelayMs: number, nodeMaxWaitMs: number) {
+  private setupAutoSpacePageObserver(nodeDelayMs: number, nodeMaxWaitMs: number) {
     // Disconnect any existing auto-spacing observer
-    if (this.autoSpacingPageObserver) {
-      this.autoSpacingPageObserver.disconnect();
-      this.autoSpacingPageObserver = null;
+    if (this.autoSpacePageObserver) {
+      this.autoSpacePageObserver.disconnect();
+      this.autoSpacePageObserver = null;
     }
 
     const queue: Node[] = [];
 
-    // Debounce timers outlive disconnect(): both callbacks bail once stopAutoSpacingPage() dropped this observer
+    // Debounce timers outlive disconnect(): both callbacks bail once stopAutoSpacePage() dropped this observer
     const debouncedSpacingTitle = debounce(
       () => {
-        if (this.autoSpacingPageObserver !== observer) {
+        if (this.autoSpacePageObserver !== observer) {
           return;
         }
         const titleElement = document.querySelector('head > title');
         if (titleElement) {
-          this.spacingNode(titleElement);
+          this.spaceNode(titleElement);
         }
       },
       nodeDelayMs,
@@ -523,7 +523,7 @@ export class BrowserPangu extends Pangu {
 
     const debouncedSpacingQueuedNodes = debounce(
       () => {
-        if (this.autoSpacingPageObserver !== observer) {
+        if (this.autoSpacePageObserver !== observer) {
           return;
         }
         // NOTE: a single node could be very big which contains a lot of child nodes
@@ -558,7 +558,7 @@ export class BrowserPangu extends Pangu {
         }
         allTextNodes.reverse();
 
-        this.schedule(() => this.spacingTextNodes(allTextNodes));
+        this.schedule(() => this.spaceTextNodes(allTextNodes));
       },
       nodeDelayMs,
       nodeMaxWaitMs,
@@ -569,7 +569,7 @@ export class BrowserPangu extends Pangu {
       let titleChanged = false;
 
       // If this batch removed content we already spaced, there is usually a page re-render
-      // So the added nodes below are re-spaced with spacingNodeSync(), before the browser paints the re-rendered text
+      // So the added nodes below are re-spaced with spaceNodeSync(), before the browser paints the re-rendered text
       let removedSpacedContent = false;
       for (const mutation of mutations) {
         for (const node of mutation.removedNodes) {
@@ -606,7 +606,7 @@ export class BrowserPangu extends Pangu {
 
                 // The current text node's data doesn't match what we last wrote, which usually means there is a page re-render
                 // So re-space it before the next paint so the re-render never paints
-                if (this.spacingNodeSync(node.parentNode, BrowserPangu.maxSyncTextNodes)) {
+                if (this.spaceNodeSync(node.parentNode, BrowserPangu.maxSyncTextNodes)) {
                   break;
                 }
               }
@@ -620,12 +620,12 @@ export class BrowserPangu extends Pangu {
             // New nodes added to DOM (e.g., innerHTML change, appendChild)
             for (const node of mutation.addedNodes) {
               if (node.nodeType === Node.ELEMENT_NODE) {
-                if (removedSpacedContent && this.spacingNodeSync(node, BrowserPangu.maxSyncTextNodes)) {
+                if (removedSpacedContent && this.spaceNodeSync(node, BrowserPangu.maxSyncTextNodes)) {
                   continue;
                 }
                 queue.push(node); // Element added, process its text content
               } else if (node.nodeType === Node.TEXT_NODE && node.parentNode) {
-                if (removedSpacedContent && this.spacingNodeSync(node.parentNode, BrowserPangu.maxSyncTextNodes)) {
+                if (removedSpacedContent && this.spaceNodeSync(node.parentNode, BrowserPangu.maxSyncTextNodes)) {
                   continue;
                 }
                 queue.push(node.parentNode); // Text node added, process its parent
@@ -644,7 +644,7 @@ export class BrowserPangu extends Pangu {
 
       debouncedSpacingQueuedNodes();
     });
-    this.autoSpacingPageObserver = observer;
+    this.autoSpacePageObserver = observer;
 
     // A single MutationObserver can observe multiple targets simultaneously
     observer.observe(document.head, {

--- a/src/browser/pangu.ts
+++ b/src/browser/pangu.ts
@@ -507,7 +507,7 @@ export class BrowserPangu extends Pangu {
     const queue: Node[] = [];
 
     // Debounce timers outlive disconnect(): both callbacks bail once stopAutoSpacePage() dropped this observer
-    const debouncedSpacingTitle = debounce(
+    const spaceTitleDebounced = debounce(
       () => {
         if (this.autoSpacePageObserver !== observer) {
           return;
@@ -521,7 +521,7 @@ export class BrowserPangu extends Pangu {
       nodeMaxWaitMs,
     );
 
-    const debouncedSpacingQueuedNodes = debounce(
+    const spaceQueuedNodesDebounced = debounce(
       () => {
         if (this.autoSpacePageObserver !== observer) {
           return;
@@ -586,7 +586,7 @@ export class BrowserPangu extends Pangu {
       // Element: https://developer.mozilla.org/en-US/docs/Web/API/Element
       // Text: https://developer.mozilla.org/en-US/docs/Web/API/Text
       for (const mutation of mutations) {
-        // Skip to avoid double processing - title handled separately by debouncedSpacingTitle()
+        // Skip to avoid double processing - title handled separately by spaceTitleDebounced()
         if (mutation.target.parentNode?.nodeName === 'TITLE' || mutation.target.nodeName === 'TITLE') {
           titleChanged = true;
           continue;
@@ -639,10 +639,10 @@ export class BrowserPangu extends Pangu {
       }
 
       if (titleChanged) {
-        debouncedSpacingTitle();
+        spaceTitleDebounced();
       }
 
-      debouncedSpacingQueuedNodes();
+      spaceQueuedNodesDebounced();
     });
     this.autoSpacePageObserver = observer;
 

--- a/src/browser/pangu.ts
+++ b/src/browser/pangu.ts
@@ -170,7 +170,7 @@ export class BrowserPangu extends Pangu {
   }
 
   private spaceTextNodes(textNodes: Node[]) {
-    // Visibility verdicts are memoized per batch; styles may change between batches
+    // Visibility answers are memoized per batch; styles may change between batches
     this.visibilityDetector.clearCache();
 
     // Text nodes waiting for the batch to settle: unspaced text captured now, settled text read at the batch tail
@@ -215,7 +215,7 @@ export class BrowserPangu extends Pangu {
         const currentTail = currentTextNode.data.slice(-3);
         const nextFirst = nextTextNode.data.slice(0, 1);
 
-        const boundarySpacingVerdict = decideBoundarySpacing({
+        const boundarySpacingDecision = decideBoundarySpacing({
           currentTail,
           nextFirst,
           currentEndsWithSpace: TRAILING_WHITESPACE.test(currentTextNode.data),
@@ -237,7 +237,7 @@ export class BrowserPangu extends Pangu {
         });
 
         // A junction space can come with a second space that belongs inside the current text node's tail (CJK/ + CJK reads CJK / CJK): write the respaced tail back before placing the junction space
-        if (boundarySpacingVerdict !== 'none' && !this.holdsLateFix(currentTextNode)) {
+        if (boundarySpacingDecision !== 'none' && !this.holdsLateFix(currentTextNode)) {
           const respacedTail = respaceCurrentTail(currentTail, nextFirst);
           if (respacedTail !== null) {
             currentTextNode.data = currentTextNode.data.slice(0, currentTextNode.data.length - currentTail.length) + respacedTail;
@@ -245,7 +245,7 @@ export class BrowserPangu extends Pangu {
           }
         }
 
-        switch (boundarySpacingVerdict) {
+        switch (boundarySpacingDecision) {
           case 'prepend-next':
             nextTextNode.data = ` ${nextTextNode.data}`;
             this.lastWrittenData.set(nextTextNode, nextTextNode.data);
@@ -287,14 +287,14 @@ export class BrowserPangu extends Pangu {
   private applyTextNodeSpacing(textNode: Text, unsettledTextNodes: UnsettledTextNode[]) {
     // A node the rules space again no longer holds a late fix
     this.lateFixedTextNodes.delete(textNode);
-    const textNodeSpacingVerdicts = decideTextNodeSpacing({
+    const textNodeSpacingDecisions = decideTextNodeSpacing({
       text: textNode.data,
       previousElementLastChar: this.findPreviousElementLastChar(textNode),
       hiddenBoundaryBefore: () => this.isHiddenBoundaryBefore(textNode),
     });
 
-    for (const textNodeSpacingVerdict of textNodeSpacingVerdicts) {
-      switch (textNodeSpacingVerdict) {
+    for (const textNodeSpacingDecision of textNodeSpacingDecisions) {
+      switch (textNodeSpacingDecision) {
         case 'trim-leading-space':
           textNode.data = textNode.data.substring(1);
           this.lastWrittenData.set(textNode, textNode.data);

--- a/src/browser/pangu.ts
+++ b/src/browser/pangu.ts
@@ -494,12 +494,6 @@ export class BrowserPangu extends Pangu {
   }
 
   private setupAutoSpacePageObserver(nodeDelayMs: number, nodeMaxWaitMs: number) {
-    // Disconnect any existing auto-spacing observer
-    if (this.autoSpacePageObserver) {
-      this.autoSpacePageObserver.disconnect();
-      this.autoSpacePageObserver = null;
-    }
-
     const queue: Node[] = [];
 
     // Debounce timers outlive disconnect(): both callbacks bail once stopAutoSpacePage() dropped this observer

--- a/src/browser/pangu.ts
+++ b/src/browser/pangu.ts
@@ -71,7 +71,6 @@ export class BrowserPangu extends Pangu {
   // Pre-paint re-space stays bounded: subtrees with more text nodes than this fall back to the queue
   private static readonly maxSyncTextNodes = 256;
 
-  private isAutoSpacePageExecuted = false;
   private autoSpacePageObserver: MutationObserver | null = null;
 
   // Last data we wrote per text node: distinguishes pangu's own mutation records
@@ -96,11 +95,10 @@ export class BrowserPangu extends Pangu {
       return;
     }
 
-    if (this.isAutoSpacePageExecuted) {
+    if (this.autoSpacePageObserver) {
       return;
     }
 
-    this.isAutoSpacePageExecuted = true;
     const observer = this.setupAutoSpacePageObserver(nodeDelayMs, nodeMaxWaitMs);
 
     // Skipped once stopAutoSpacePage() dropped this observer before the delay elapsed
@@ -136,8 +134,6 @@ export class BrowserPangu extends Pangu {
       this.autoSpacePageObserver.disconnect();
       this.autoSpacePageObserver = null;
     }
-
-    this.isAutoSpacePageExecuted = false;
   }
 
   public applyLateFixes(lateFixes: readonly LateFix[]) {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -47,9 +47,9 @@ async function readStdin() {
   return chunks.join('').replace(/\n$/, '');
 }
 
-function printSpacingText(text: string | undefined) {
+function printSpaceText(text: string | undefined) {
   if (typeof text === 'string') {
-    console.log(pangu.spacingText(text));
+    console.log(pangu.spaceText(text));
   } else {
     console.log(usage);
     process.exitCode = 1;
@@ -57,10 +57,10 @@ function printSpacingText(text: string | undefined) {
 }
 
 // An empty string is what -f "$EMPTY_VAR" expands to, so it counts as a missing path rather than a file to open
-function printSpacingFile(path: string | undefined) {
+function printSpaceFile(path: string | undefined) {
   if (path) {
     // File mode only does spacing: no newline appended, the file's own EOF newlines (or lack of one) pass through untouched
-    process.stdout.write(pangu.spacingFileSync(path));
+    process.stdout.write(pangu.spaceFileSync(path));
   } else {
     console.error('pangu: error: argument --file: expected a file path');
     console.log(usage);
@@ -73,7 +73,7 @@ function checkSpacing(text: string | undefined) {
     const hasProperSpacing = pangu.hasProperSpacing(text);
     if (!hasProperSpacing) {
       // Print the corrected version to stderr so a failing -c is debuggable. stdout stays empty, so -c composes in a pipeline
-      console.error(`Corrected: ${pangu.spacingText(text)}`);
+      console.error(`Corrected: ${pangu.spaceText(text)}`);
     }
     process.exitCode = hasProperSpacing ? 0 : 1;
   } else {
@@ -95,7 +95,7 @@ async function main() {
   }
 
   if (args.length === 0) {
-    printSpacingText(wantsStdin(undefined) ? await readStdin() : undefined);
+    printSpaceText(wantsStdin(undefined) ? await readStdin() : undefined);
     return;
   }
 
@@ -110,16 +110,16 @@ async function main() {
       break;
     case '-t':
     case '--text':
-      printSpacingText(wantsStdin(args[1]) ? await readStdin() : args[1]);
+      printSpaceText(wantsStdin(args[1]) ? await readStdin() : args[1]);
       break;
     case '-f':
     case '--file':
       // An explicit - is the conventional spelling for "the file is stdin" (cf. tar -f -). A missing path is a usage error instead of a stdin fallback, so that -f with an empty path variable
       // reports the missing path instead of silently spacing whatever happens to be piped in
       if (args[1] === '-') {
-        printSpacingText(await readStdin());
+        printSpaceText(await readStdin());
       } else {
-        printSpacingFile(args[1]);
+        printSpaceFile(args[1]);
       }
       break;
     case '-c':
@@ -127,10 +127,10 @@ async function main() {
       checkSpacing(wantsStdin(args[1]) ? await readStdin() : args[1]);
       break;
     case '-':
-      printSpacingText(await readStdin());
+      printSpaceText(await readStdin());
       break;
     default:
-      printSpacingText(args[0]);
+      printSpaceText(args[0]);
   }
 }
 

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -47,7 +47,7 @@ async function readStdin() {
   return chunks.join('').replace(/\n$/, '');
 }
 
-function printSpaceText(text: string | undefined) {
+function spaceTextPrinted(text: string | undefined) {
   if (typeof text === 'string') {
     console.log(pangu.spaceText(text));
   } else {
@@ -57,7 +57,7 @@ function printSpaceText(text: string | undefined) {
 }
 
 // An empty string is what -f "$EMPTY_VAR" expands to, so it counts as a missing path rather than a file to open
-function printSpaceFile(path: string | undefined) {
+function spaceFilePrinted(path: string | undefined) {
   if (path) {
     // File mode only does spacing: no newline appended, the file's own EOF newlines (or lack of one) pass through untouched
     process.stdout.write(pangu.spaceFileSync(path));
@@ -95,7 +95,7 @@ async function main() {
   }
 
   if (args.length === 0) {
-    printSpaceText(wantsStdin(undefined) ? await readStdin() : undefined);
+    spaceTextPrinted(wantsStdin(undefined) ? await readStdin() : undefined);
     return;
   }
 
@@ -110,16 +110,16 @@ async function main() {
       break;
     case '-t':
     case '--text':
-      printSpaceText(wantsStdin(args[1]) ? await readStdin() : args[1]);
+      spaceTextPrinted(wantsStdin(args[1]) ? await readStdin() : args[1]);
       break;
     case '-f':
     case '--file':
       // An explicit - is the conventional spelling for "the file is stdin" (cf. tar -f -). A missing path is a usage error instead of a stdin fallback, so that -f with an empty path variable
       // reports the missing path instead of silently spacing whatever happens to be piped in
       if (args[1] === '-') {
-        printSpaceText(await readStdin());
+        spaceTextPrinted(await readStdin());
       } else {
-        printSpaceFile(args[1]);
+        spaceFilePrinted(args[1]);
       }
       break;
     case '-c':
@@ -127,10 +127,10 @@ async function main() {
       checkSpacing(wantsStdin(args[1]) ? await readStdin() : args[1]);
       break;
     case '-':
-      printSpaceText(await readStdin());
+      spaceTextPrinted(await readStdin());
       break;
     default:
-      printSpaceText(args[0]);
+      spaceTextPrinted(args[0]);
   }
 }
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -3,13 +3,13 @@ import { readFile } from 'node:fs/promises';
 import { Pangu } from '../shared/index.js';
 
 export class NodePangu extends Pangu {
-  async spacingFile(path: string) {
+  async spaceFile(path: string) {
     const data = await readFile(path, 'utf8');
-    return this.spacingText(data);
+    return this.spaceText(data);
   }
 
-  spacingFileSync(path: string) {
-    return this.spacingText(readFileSync(path, 'utf8'));
+  spaceFileSync(path: string) {
+    return this.spaceText(readFileSync(path, 'utf8'));
   }
 }
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -274,9 +274,9 @@ export class Pangu {
     this.version = '10.0.0';
   }
 
-  public spacingText(text: string) {
+  public spaceText(text: string) {
     if (typeof text !== 'string') {
-      console.warn(`[pangu] spacingText(text) only accepts string but got ${typeof text}`);
+      console.warn(`[pangu] spaceText(text) only accepts string but got ${typeof text}`);
       return text;
     }
 
@@ -317,7 +317,7 @@ export class Pangu {
           }
         }
         const processedTag = match.replace(/(\w+)="([^"]*)"/g, (_attrMatch, attrName: string, attrValue: string) => {
-          const processedValue = this.spacingText(attrValue);
+          const processedValue = this.spaceText(attrValue);
           return `${attrName}="${processedValue}"`;
         });
 
@@ -489,7 +489,7 @@ export class Pangu {
   }
 
   public hasProperSpacing(text: string) {
-    return this.spacingText(text) === text;
+    return this.spaceText(text) === text;
   }
 
   // Strip the spaces that earlier rules left just inside a bracket pair: no space after an opening bracket or before a closing bracket

--- a/tests/browser/boundary-spacing.test.ts
+++ b/tests/browser/boundary-spacing.test.ts
@@ -3,7 +3,7 @@ import type { BoundarySpacingContext, BoundarySpacingVerdict, TextNodeSpacingCon
 import { decideBoundarySpacing, decideTextNodeSpacing, respaceCurrentTail } from '../../src/browser/boundary-spacing';
 
 // A boundary that the spacing engine wants a space at, with every veto turned off
-const spacingBoundary: BoundarySpacingContext = {
+const boundarySpacingContext: BoundarySpacingContext = {
   currentTail: '中',
   nextFirst: 'a',
   currentEndsWithSpace: false,
@@ -56,7 +56,7 @@ interface TextNodeCase {
 }
 
 function boundaryContext(overrides: Partial<BoundarySpacingContext>) {
-  return { ...spacingBoundary, ...overrides };
+  return { ...boundarySpacingContext, ...overrides };
 }
 
 function textNodeContext(overrides: Partial<TextNodeSpacingContext>) {

--- a/tests/browser/boundary-spacing.test.ts
+++ b/tests/browser/boundary-spacing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { BoundarySpacingContext, BoundarySpacingVerdict, TextNodeSpacingContext, TextNodeSpacingVerdict } from '../../src/browser/boundary-spacing';
+import type { BoundarySpacingContext, BoundarySpacingDecision, TextNodeSpacingContext, TextNodeSpacingDecision } from '../../src/browser/boundary-spacing';
 import { decideBoundarySpacing, decideTextNodeSpacing, respaceCurrentTail } from '../../src/browser/boundary-spacing';
 
 // A boundary that the spacing engine wants a space at, with every veto turned off
@@ -24,7 +24,7 @@ const boundarySpacingContext: BoundarySpacingContext = {
   inGridOrFlexContainer: () => false,
 };
 
-// A layout-dependent fact that the verdict must not need on this path
+// A layout-dependent fact that the decision must not need on this path
 function neverConsulted(name: string): () => boolean {
   return () => {
     throw new Error(`${name} must not be consulted`);
@@ -46,13 +46,13 @@ const textNode: TextNodeSpacingContext = {
 interface BoundaryCase {
   name: string;
   context: Partial<BoundarySpacingContext>;
-  verdict: BoundarySpacingVerdict;
+  decision: BoundarySpacingDecision;
 }
 
 interface TextNodeCase {
   name: string;
   context: Partial<TextNodeSpacingContext>;
-  verdicts: TextNodeSpacingVerdict[];
+  decisions: TextNodeSpacingDecision[];
 }
 
 function boundaryContext(overrides: Partial<BoundarySpacingContext>) {
@@ -64,96 +64,96 @@ function textNodeContext(overrides: Partial<TextNodeSpacingContext>) {
 }
 
 describe('decideBoundarySpacing()', () => {
-  const verdictCases: BoundaryCase[] = [
-    { name: 'prepends to the next text node when neither boundary is space-sensitive', context: {}, verdict: 'prepend-next' },
-    { name: 'appends to the current text node when only the next boundary is space-sensitive', context: appendCurrentBoundary, verdict: 'append-current' },
-    { name: 'inserts an element when both boundaries are space-sensitive', context: insertElementBoundary, verdict: 'insert-element' },
-    { name: 'does nothing when collectable text sits between the nodes', context: { contentBetween: true }, verdict: 'none' },
-    { name: 'does nothing when collectable text sits between space-sensitive nodes', context: { ...insertElementBoundary, contentBetween: true }, verdict: 'none' },
-    { name: 'does nothing when the current boundary is a block', context: { currentBoundaryIsBlock: true }, verdict: 'none' },
-    { name: 'does nothing when the next boundary is ignored', context: { nextBoundaryIsIgnored: true }, verdict: 'none' },
-    { name: 'does nothing when the next boundary is a block', context: { nextBoundaryIsBlock: true }, verdict: 'none' },
+  const decisionCases: BoundaryCase[] = [
+    { name: 'prepends to the next text node when neither boundary is space-sensitive', context: {}, decision: 'prepend-next' },
+    { name: 'appends to the current text node when only the next boundary is space-sensitive', context: appendCurrentBoundary, decision: 'append-current' },
+    { name: 'inserts an element when both boundaries are space-sensitive', context: insertElementBoundary, decision: 'insert-element' },
+    { name: 'does nothing when collectable text sits between the nodes', context: { contentBetween: true }, decision: 'none' },
+    { name: 'does nothing when collectable text sits between space-sensitive nodes', context: { ...insertElementBoundary, contentBetween: true }, decision: 'none' },
+    { name: 'does nothing when the current boundary is a block', context: { currentBoundaryIsBlock: true }, decision: 'none' },
+    { name: 'does nothing when the next boundary is ignored', context: { nextBoundaryIsIgnored: true }, decision: 'none' },
+    { name: 'does nothing when the next boundary is a block', context: { nextBoundaryIsBlock: true }, decision: 'none' },
   ];
 
-  it.each(verdictCases)('$name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(decisionCases)('$name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 
   const existingSpaceCases: BoundaryCase[] = [
-    { name: 'the current text node already ends with a space', context: { currentEndsWithSpace: true }, verdict: 'none' },
-    { name: 'the next text node already starts with a space', context: { nextStartsWithSpace: true }, verdict: 'none' },
-    { name: 'whitespace sits between the two text nodes', context: { whitespaceBetween: true }, verdict: 'none' },
-    { name: 'a space-like sibling follows the current text node', context: { spaceLikeSiblingAfterCurrent: true }, verdict: 'none' },
-    { name: 'a space-like sibling follows the current boundary', context: { spaceLikeSiblingAfterCurrentBoundary: true }, verdict: 'none' },
-    { name: 'a space-like sibling precedes the next text node', context: { spaceLikeSiblingBeforeNext: true }, verdict: 'none' },
+    { name: 'the current text node already ends with a space', context: { currentEndsWithSpace: true }, decision: 'none' },
+    { name: 'the next text node already starts with a space', context: { nextStartsWithSpace: true }, decision: 'none' },
+    { name: 'whitespace sits between the two text nodes', context: { whitespaceBetween: true }, decision: 'none' },
+    { name: 'a space-like sibling follows the current text node', context: { spaceLikeSiblingAfterCurrent: true }, decision: 'none' },
+    { name: 'a space-like sibling follows the current boundary', context: { spaceLikeSiblingAfterCurrentBoundary: true }, decision: 'none' },
+    { name: 'a space-like sibling precedes the next text node', context: { spaceLikeSiblingBeforeNext: true }, decision: 'none' },
   ];
 
-  it.each(existingSpaceCases)('does nothing when $name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(existingSpaceCases)('does nothing when $name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 
   const probeCases: BoundaryCase[] = [
-    { name: 'CJK then half-width', context: { currentTail: '中', nextFirst: 'a' }, verdict: 'prepend-next' },
-    { name: 'half-width then CJK', context: { currentTail: 'a', nextFirst: '中' }, verdict: 'prepend-next' },
-    { name: 'kana then half-width', context: { currentTail: 'の', nextFirst: 'a' }, verdict: 'prepend-next' },
-    { name: 'CJK then CJK', context: { currentTail: '中', nextFirst: '文' }, verdict: 'none' },
-    { name: 'half-width then half-width', context: { currentTail: 'a', nextFirst: 'b' }, verdict: 'none' },
+    { name: 'CJK then half-width', context: { currentTail: '中', nextFirst: 'a' }, decision: 'prepend-next' },
+    { name: 'half-width then CJK', context: { currentTail: 'a', nextFirst: '中' }, decision: 'prepend-next' },
+    { name: 'kana then half-width', context: { currentTail: 'の', nextFirst: 'a' }, decision: 'prepend-next' },
+    { name: 'CJK then CJK', context: { currentTail: '中', nextFirst: '文' }, decision: 'none' },
+    { name: 'half-width then half-width', context: { currentTail: 'a', nextFirst: 'b' }, decision: 'none' },
     // Hangul is outside the CJK class of shared, so the probe reports no spacing
-    { name: 'hangul then half-width', context: { currentTail: '한', nextFirst: 'a' }, verdict: 'none' },
+    { name: 'hangul then half-width', context: { currentTail: '한', nextFirst: 'a' }, decision: 'none' },
     // AN_COLON_CJK needs the alphanumeric character before the colon, so the
-    // verdict flips with the tail context
-    { name: 'colon with alphanumeric context then CJK', context: { currentTail: 'g:', nextFirst: '低' }, verdict: 'prepend-next' },
-    { name: 'colon without context then CJK', context: { currentTail: ':', nextFirst: '低' }, verdict: 'none' },
+    // decision flips with the tail context
+    { name: 'colon with alphanumeric context then CJK', context: { currentTail: 'g:', nextFirst: '低' }, decision: 'prepend-next' },
+    { name: 'colon without context then CJK', context: { currentTail: ':', nextFirst: '低' }, decision: 'none' },
     // The probe spaces inside the tail here (中 g), never at the junction
-    { name: 'a space that belongs inside the tail', context: { currentTail: '中g', nextFirst: 'x' }, verdict: 'none' },
+    { name: 'a space that belongs inside the tail', context: { currentTail: '中g', nextFirst: 'x' }, decision: 'none' },
 
     // FIXME: Reverted with the flush-boundary spacing feature; needs the nextHead context field back. Re-enable with the feature
     // The junction alone has no CJK, but nextHead reaches the 十 inside the brackets, so AN_LEFT_BRACKET gets its context (the Google Calendar case)
-    // { name: 'a CJK just past the junction window', context: { currentTail: 'g 1', nextFirst: '(', nextHead: '(十九)' }, verdict: 'prepend-next' },
-    // { name: 'no CJK anywhere near the junction', context: { currentTail: 'g 1', nextFirst: '(', nextHead: '(999' }, verdict: 'none' },
+    // { name: 'a CJK just past the junction window', context: { currentTail: 'g 1', nextFirst: '(', nextHead: '(十九)' }, decision: 'prepend-next' },
+    // { name: 'no CJK anywhere near the junction', context: { currentTail: 'g 1', nextFirst: '(', nextHead: '(999' }, decision: 'none' },
   ];
 
-  it.each(probeCases)('probes the spacing engine with $name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(probeCases)('probes the spacing engine with $name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 
   const quoteCases: BoundaryCase[] = [
-    { name: 'a straight quote before CJK', context: { currentTail: '"', nextFirst: '中' }, verdict: 'none' },
-    { name: 'CJK before a straight quote', context: { currentTail: '中', nextFirst: '"' }, verdict: 'none' },
-    { name: 'a curly quote before CJK', context: { currentTail: '“', nextFirst: '中' }, verdict: 'none' },
-    { name: 'CJK before a curly quote', context: { currentTail: '中', nextFirst: '”' }, verdict: 'none' },
-    { name: 'kana before a straight quote', context: { currentTail: 'の', nextFirst: '"' }, verdict: 'none' },
-    { name: 'a straight quote before kana', context: { currentTail: '"', nextFirst: 'の' }, verdict: 'none' },
-    { name: 'a quote at the tail end before CJK', context: { currentTail: '文"', nextFirst: '中' }, verdict: 'none' }, // The veto reads the last character of the tail, not the whole tail
+    { name: 'a straight quote before CJK', context: { currentTail: '"', nextFirst: '中' }, decision: 'none' },
+    { name: 'CJK before a straight quote', context: { currentTail: '中', nextFirst: '"' }, decision: 'none' },
+    { name: 'a curly quote before CJK', context: { currentTail: '“', nextFirst: '中' }, decision: 'none' },
+    { name: 'CJK before a curly quote', context: { currentTail: '中', nextFirst: '”' }, decision: 'none' },
+    { name: 'kana before a straight quote', context: { currentTail: 'の', nextFirst: '"' }, decision: 'none' },
+    { name: 'a straight quote before kana', context: { currentTail: '"', nextFirst: 'の' }, decision: 'none' },
+    { name: 'a quote at the tail end before CJK', context: { currentTail: '文"', nextFirst: '中' }, decision: 'none' }, // The veto reads the last character of the tail, not the whole tail
   ];
 
-  it.each(quoteCases)('skips spacing for $name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(quoteCases)('skips spacing for $name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 
   const visibilityCases: BoundaryCase[] = [
-    { name: 'a hidden boundary before vetoes prepend-next', context: { hiddenBoundaryBefore: () => true }, verdict: 'none' },
-    { name: 'a hidden boundary after vetoes append-current', context: { ...appendCurrentBoundary, hiddenBoundaryAfter: () => true }, verdict: 'none' },
-    { name: 'a hidden boundary after vetoes insert-element', context: { ...insertElementBoundary, hiddenBoundaryAfter: () => true }, verdict: 'none' },
-    { name: 'a hidden boundary after leaves prepend-next alone', context: { hiddenBoundaryAfter: () => true }, verdict: 'prepend-next' },
-    { name: 'a hidden boundary before leaves append-current alone', context: { ...appendCurrentBoundary, hiddenBoundaryBefore: () => true }, verdict: 'append-current' },
-    { name: 'a hidden boundary before leaves insert-element alone', context: { ...insertElementBoundary, hiddenBoundaryBefore: () => true }, verdict: 'insert-element' },
+    { name: 'a hidden boundary before vetoes prepend-next', context: { hiddenBoundaryBefore: () => true }, decision: 'none' },
+    { name: 'a hidden boundary after vetoes append-current', context: { ...appendCurrentBoundary, hiddenBoundaryAfter: () => true }, decision: 'none' },
+    { name: 'a hidden boundary after vetoes insert-element', context: { ...insertElementBoundary, hiddenBoundaryAfter: () => true }, decision: 'none' },
+    { name: 'a hidden boundary after leaves prepend-next alone', context: { hiddenBoundaryAfter: () => true }, decision: 'prepend-next' },
+    { name: 'a hidden boundary before leaves append-current alone', context: { ...appendCurrentBoundary, hiddenBoundaryBefore: () => true }, decision: 'append-current' },
+    { name: 'a hidden boundary before leaves insert-element alone', context: { ...insertElementBoundary, hiddenBoundaryBefore: () => true }, decision: 'insert-element' },
   ];
 
-  it.each(visibilityCases)('$name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(visibilityCases)('$name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 
   const insertElementCases: BoundaryCase[] = [
-    { name: 'a Grid/Flexbox container downgrades insert-element', context: { ...insertElementBoundary, inGridOrFlexContainer: () => true }, verdict: 'none' },
-    { name: 'a space-like sibling before the next boundary downgrades insert-element', context: { ...insertElementBoundary, spaceLikeSiblingBeforeNextBoundary: true }, verdict: 'none' },
-    { name: 'a Grid/Flexbox container leaves prepend-next alone', context: { inGridOrFlexContainer: () => true }, verdict: 'prepend-next' },
-    { name: 'a Grid/Flexbox container leaves append-current alone', context: { ...appendCurrentBoundary, inGridOrFlexContainer: () => true }, verdict: 'append-current' },
-    { name: 'a space-like sibling before the next boundary leaves prepend-next alone', context: { spaceLikeSiblingBeforeNextBoundary: true }, verdict: 'prepend-next' },
+    { name: 'a Grid/Flexbox container downgrades insert-element', context: { ...insertElementBoundary, inGridOrFlexContainer: () => true }, decision: 'none' },
+    { name: 'a space-like sibling before the next boundary downgrades insert-element', context: { ...insertElementBoundary, spaceLikeSiblingBeforeNextBoundary: true }, decision: 'none' },
+    { name: 'a Grid/Flexbox container leaves prepend-next alone', context: { inGridOrFlexContainer: () => true }, decision: 'prepend-next' },
+    { name: 'a Grid/Flexbox container leaves append-current alone', context: { ...appendCurrentBoundary, inGridOrFlexContainer: () => true }, decision: 'append-current' },
+    { name: 'a space-like sibling before the next boundary leaves prepend-next alone', context: { spaceLikeSiblingBeforeNextBoundary: true }, decision: 'prepend-next' },
   ];
 
-  it.each(insertElementCases)('$name', ({ context, verdict }) => {
-    expect(decideBoundarySpacing(boundaryContext(context))).toBe(verdict);
+  it.each(insertElementCases)('$name', ({ context, decision }) => {
+    expect(decideBoundarySpacing(boundaryContext(context))).toBe(decision);
   });
 });
 
@@ -173,42 +173,42 @@ describe('respaceCurrentTail()', () => {
 
 describe('decideTextNodeSpacing()', () => {
   const trimCases: TextNodeCase[] = [
-    { name: 'trims a leading space that comes after a hidden element', context: { text: ' 中文abc', hiddenBoundaryBefore: () => true }, verdicts: ['trim-leading-space', 'apply-text-spacing'] },
-    { name: 'keeps a leading space that comes after a visible element', context: { text: ' 中文abc', hiddenBoundaryBefore: () => false }, verdicts: ['apply-text-spacing'] },
-    { name: 'has nothing to trim after a hidden element', context: { text: '中文abc', hiddenBoundaryBefore: () => true }, verdicts: ['apply-text-spacing'] },
+    { name: 'trims a leading space that comes after a hidden element', context: { text: ' 中文abc', hiddenBoundaryBefore: () => true }, decisions: ['trim-leading-space', 'apply-text-spacing'] },
+    { name: 'keeps a leading space that comes after a visible element', context: { text: ' 中文abc', hiddenBoundaryBefore: () => false }, decisions: ['apply-text-spacing'] },
+    { name: 'has nothing to trim after a hidden element', context: { text: '中文abc', hiddenBoundaryBefore: () => true }, decisions: ['apply-text-spacing'] },
   ];
 
-  it.each(trimCases)('$name', ({ context, verdicts }) => {
-    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(verdicts);
+  it.each(trimCases)('$name', ({ context, decisions }) => {
+    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(decisions);
   });
 
   const standaloneQuoteCases: TextNodeCase[] = [
-    { name: 'a straight quote after CJK', context: { text: '"', previousElementLastChar: '中' }, verdicts: ['prepend-space'] },
-    { name: 'a left curly quote after CJK', context: { text: '“', previousElementLastChar: '中' }, verdicts: ['prepend-space'] },
-    { name: 'a right curly quote after CJK', context: { text: '”', previousElementLastChar: '中' }, verdicts: ['prepend-space'] },
-    { name: 'a straight quote after kana', context: { text: '"', previousElementLastChar: 'の' }, verdicts: ['prepend-space'] },
+    { name: 'a straight quote after CJK', context: { text: '"', previousElementLastChar: '中' }, decisions: ['prepend-space'] },
+    { name: 'a left curly quote after CJK', context: { text: '“', previousElementLastChar: '中' }, decisions: ['prepend-space'] },
+    { name: 'a right curly quote after CJK', context: { text: '”', previousElementLastChar: '中' }, decisions: ['prepend-space'] },
+    { name: 'a straight quote after kana', context: { text: '"', previousElementLastChar: 'の' }, decisions: ['prepend-space'] },
   ];
 
-  it.each(standaloneQuoteCases)('prepends a space to $name', ({ context, verdicts }) => {
-    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(verdicts);
+  it.each(standaloneQuoteCases)('prepends a space to $name', ({ context, decisions }) => {
+    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(decisions);
   });
 
   const quoteSkipCases: TextNodeCase[] = [
-    { name: 'the previous element ends with half-width', context: { text: '"', previousElementLastChar: 'a' }, verdicts: [] },
-    { name: 'there is no previous element', context: { text: '"', previousElementLastChar: null }, verdicts: [] },
+    { name: 'the previous element ends with half-width', context: { text: '"', previousElementLastChar: 'a' }, decisions: [] },
+    { name: 'there is no previous element', context: { text: '"', previousElementLastChar: null }, decisions: [] },
   ];
 
-  it.each(quoteSkipCases)('leaves a standalone quote alone when $name', ({ context, verdicts }) => {
-    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(verdicts);
+  it.each(quoteSkipCases)('leaves a standalone quote alone when $name', ({ context, decisions }) => {
+    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(decisions);
   });
 
   const textSpacingCases: TextNodeCase[] = [
-    { name: 'more than one character', context: { text: '""', previousElementLastChar: '中' }, verdicts: ['apply-text-spacing'] },
-    { name: 'a single character that is not a quote', context: { text: 'a', previousElementLastChar: '中' }, verdicts: ['apply-text-spacing'] },
+    { name: 'more than one character', context: { text: '""', previousElementLastChar: '中' }, decisions: ['apply-text-spacing'] },
+    { name: 'a single character that is not a quote', context: { text: 'a', previousElementLastChar: '中' }, decisions: ['apply-text-spacing'] },
   ];
 
-  it.each(textSpacingCases)('applies text spacing to a text node of $name', ({ context, verdicts }) => {
-    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(verdicts);
+  it.each(textSpacingCases)('applies text spacing to a text node of $name', ({ context, decisions }) => {
+    expect(decideTextNodeSpacing(textNodeContext(context))).toEqual(decisions);
   });
 
   it('trims a leading space before deciding that the rest is a standalone quote', () => {

--- a/tests/browser/imports.playwright.ts
+++ b/tests/browser/imports.playwright.ts
@@ -12,14 +12,14 @@ test.describe('Browser UMD imports', () => {
     const result = await page.evaluate(() => {
       return {
         hasGlobalPangu: typeof window.pangu !== 'undefined',
-        hasAutoSpacingPage: typeof window.pangu.autoSpacingPage === 'function',
+        hasAutoSpacePage: typeof window.pangu.autoSpacePage === 'function',
         hasBrowserPanguClass: typeof window.pangu.BrowserPangu === 'function',
         canCreateInstance: new window.pangu.BrowserPangu() instanceof window.pangu.BrowserPangu,
       };
     });
 
     expect(result.hasGlobalPangu).toBe(true);
-    expect(result.hasAutoSpacingPage).toBe(true);
+    expect(result.hasAutoSpacePage).toBe(true);
     expect(result.hasBrowserPanguClass).toBe(true);
     expect(result.canCreateInstance).toBe(true);
   });
@@ -27,7 +27,7 @@ test.describe('Browser UMD imports', () => {
   test('handle text with spacing functionality', async ({ page }) => {
     const result = await page.evaluate(() => {
       const text = 'Hello世界';
-      const spaced = pangu.spacingText(text);
+      const spaced = pangu.spaceText(text);
       return { original: text, spaced };
     });
 

--- a/tests/browser/late-fixes.playwright.ts
+++ b/tests/browser/late-fixes.playwright.ts
@@ -14,7 +14,7 @@ test.describe('applyLateFixes', () => {
     await page.setContent('<div id="target">氣溫是-5度左右</div>');
 
     const result = await page.evaluate(() => {
-      pangu.spacingNode(document.body);
+      pangu.spaceNode(document.body);
 
       const textNode = document.getElementById('target')!.firstChild as Text;
       pangu.applyLateFixes([{ node: textNode, settled: '氣溫是 - 5 度左右', data: '氣溫是 -5 度左右' }]);
@@ -28,7 +28,7 @@ test.describe('applyLateFixes', () => {
     await page.setContent('<div id="target">氣溫是-5度左右</div>');
 
     const result = await page.evaluate(() => {
-      pangu.spacingNode(document.body);
+      pangu.spaceNode(document.body);
 
       // Something else rewrote the node while the classifier was still thinking
       const textNode = document.getElementById('target')!.firstChild as Text;
@@ -44,7 +44,7 @@ test.describe('applyLateFixes', () => {
     await page.setContent('<div id="target">氣溫是-5度左右</div>');
 
     const result = await page.evaluate(() => {
-      pangu.spacingNode(document.body);
+      pangu.spaceNode(document.body);
 
       const target = document.getElementById('target')!;
       const textNode = target.firstChild as Text;
@@ -76,7 +76,7 @@ test.describe('applyLateFixes', () => {
         }
         pangu.applyLateFixes(lateFixes);
       };
-      pangu.autoSpacingPage({ pageDelayMs: 0 });
+      pangu.autoSpacePage({ pageDelayMs: 0 });
     });
 
     // Past the observer's own debounce, so a revert would have landed by now

--- a/tests/browser/pangu.playwright.ts
+++ b/tests/browser/pangu.playwright.ts
@@ -23,15 +23,15 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('autoSpacingPage()', () => {
+  test.describe('autoSpacePage()', () => {
     test('handle dynamic content with MutationObserver', async ({ page }) => {
       await page.evaluate(() => {
-        pangu.autoSpacingPage();
+        pangu.autoSpacePage();
       });
 
       await page.waitForTimeout(50);
 
-      // Dynamically add content after autoSpacingPage is active
+      // Dynamically add content after autoSpacePage is active
       await page.evaluate(() => {
         const div = document.createElement('div');
         div.textContent = '小明在開發軟體時總是嚴格地遵循各項協定與標準，直到他看了ISO 3166-1';
@@ -49,7 +49,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div id="container"></div>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage();
+        pangu.autoSpacePage();
       });
 
       await page.waitForTimeout(50);
@@ -77,7 +77,7 @@ test.describe('BrowserPangu', () => {
       // Large pageDelayMs keeps the initial page sweep out of the assertion window,
       // so only the MutationObserver drain acts
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 60000 });
+        pangu.autoSpacePage({ pageDelayMs: 60000 });
       });
 
       await page.waitForTimeout(50);
@@ -106,7 +106,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container">（<span id="count"></span>人的回答統計）</p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -125,7 +125,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container">公視+的節目<span id="count"></span></p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -152,7 +152,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container"><span>甲1</span><span>乙2</span></p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -174,7 +174,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container">公視+<span id="count"></span></p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -201,7 +201,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container">公視+的節目</p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -228,7 +228,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="container"><span id="count"></span>公視+的節目</p>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -261,7 +261,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<html><head><title>中文</title></head><body><nav><span id="count"></span>abc</nav></body></html>');
 
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 50 });
+        pangu.autoSpacePage({ pageDelayMs: 50 });
       });
 
       await page.waitForTimeout(600);
@@ -281,7 +281,7 @@ test.describe('BrowserPangu', () => {
 
       // Large pageDelayMs keeps the initial page sweep out of the assertion window
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 60000 });
+        pangu.autoSpacePage({ pageDelayMs: 60000 });
       });
 
       await page.waitForTimeout(50);
@@ -305,7 +305,7 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('stopAutoSpacingPage()', () => {
+  test.describe('stopAutoSpacePage()', () => {
     test.beforeEach(async ({ page }) => {
       await page.clock.install({ time: new Date('2026-01-01T00:00:00Z') });
       await page.clock.pauseAt(new Date('2026-01-01T00:00:01Z'));
@@ -314,8 +314,8 @@ test.describe('BrowserPangu', () => {
 
     test('skip the delayed initial sweep after stopping', async ({ page }) => {
       await page.evaluate(() => {
-        pangu.autoSpacingPage({ pageDelayMs: 100 });
-        pangu.stopAutoSpacingPage();
+        pangu.autoSpacePage({ pageDelayMs: 100 });
+        pangu.stopAutoSpacePage();
         document.title = '新title';
         document.querySelector('p')!.textContent = '新content';
       });
@@ -328,12 +328,12 @@ test.describe('BrowserPangu', () => {
 
     test('skip pending title and body debounces after stopping', async ({ page }) => {
       await page.evaluate(async () => {
-        pangu.autoSpacingPage({ pageDelayMs: 60000, nodeDelayMs: 100 });
+        pangu.autoSpacePage({ pageDelayMs: 60000, nodeDelayMs: 100 });
         document.title = '舊title';
         document.querySelector('p')!.textContent = '舊content';
         await Promise.resolve();
 
-        pangu.stopAutoSpacingPage();
+        pangu.stopAutoSpacePage();
         document.title = '新title';
         document.querySelector('p')!.textContent = '新content';
       });
@@ -346,15 +346,15 @@ test.describe('BrowserPangu', () => {
 
     test('skip callbacks from the previous activation after restarting', async ({ page }) => {
       await page.evaluate(async () => {
-        pangu.autoSpacingPage({ pageDelayMs: 100, nodeDelayMs: 100 });
+        pangu.autoSpacePage({ pageDelayMs: 100, nodeDelayMs: 100 });
         document.title = '舊title';
         document.querySelector('p')!.textContent = '舊content';
         await Promise.resolve();
 
-        pangu.stopAutoSpacingPage();
+        pangu.stopAutoSpacePage();
         document.title = '新title';
         document.querySelector('p')!.textContent = '新content';
-        pangu.autoSpacingPage({ pageDelayMs: 1000 });
+        pangu.autoSpacePage({ pageDelayMs: 1000 });
       });
 
       await page.clock.runFor(500);
@@ -369,14 +369,14 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('spacingNode()', () => {
+  test.describe('spaceNode()', () => {
     test('handle text node', async ({ page }) => {
-      // spacingNode() works on element nodes, not directly on text nodes
+      // spaceNode() works on element nodes, not directly on text nodes
       // So we need to wrap the text node in an element
       await page.setContent('<div id="test">你可以使用uname -m指令來檢查你的Linux作業系統是32位元或是[敏感词已被屏蔽]位元</div>');
       const result = await page.evaluate(() => {
         const div = document.getElementById('test')!;
-        pangu.spacingNode(div);
+        pangu.spaceNode(div);
         return div.textContent;
       });
       expect(result).toBe('你可以使用 uname -m 指令來檢查你的 Linux 作業系統是 32 位元或是 [敏感词已被屏蔽] 位元');
@@ -388,7 +388,7 @@ test.describe('BrowserPangu', () => {
       );
       const result = await page.evaluate(() => {
         const div = document.getElementById('test')!;
-        pangu.spacingNode(div);
+        pangu.spaceNode(div);
         return div.textContent;
       });
       expect(result).toBe(
@@ -403,7 +403,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test">Rev. (Reverend；牧師的尊稱) \n    這個縮寫嚴格來說並不是一項頭銜，而是形容詞。所以，它應該這樣使用：&quot;We \n    invited the Rev. Alan Darling.&quot; 或&nbsp; &quot;We&nbsp; invited the Rev. Mr. \n    Darling.&quot; ，而非 &quot;We invited the Rev. Darling.&quot; 我們也不可以說&nbsp; \n    &quot;We invited the reverend to dinner.&quot; -- Only a cad would invite the rev. (只有下流的人才會招致批評：句中的 \n    rev. 是 review 的縮寫，算是雙關語) </p>');
       const result = await page.evaluate(() => {
         const div = document.getElementById('test')!;
-        pangu.spacingNode(div);
+        pangu.spaceNode(div);
         return div.textContent;
       });
       // prettier-ignore
@@ -411,7 +411,7 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('spacingNode() with getElementById', () => {
+  test.describe('spaceNode() with getElementById', () => {
     test('handle elements by ID', async ({ page }) => {
       const htmlContent = loadFixture('id-name.html');
       const expected = loadFixture('id-name.expected.html').trim();
@@ -420,7 +420,7 @@ test.describe('BrowserPangu', () => {
       await page.evaluate(() => {
         const element = document.getElementById('e1');
         if (element) {
-          pangu.spacingNode(element);
+          pangu.spaceNode(element);
         }
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
@@ -428,7 +428,7 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('spacingNode() with getElementsByClassName', () => {
+  test.describe('spaceNode() with getElementsByClassName', () => {
     test('handle elements by class name (single element)', async ({ page }) => {
       const htmlContent = loadFixture('class-name-1.html');
       const expected = loadFixture('class-name-1.expected.html').trim();
@@ -437,7 +437,7 @@ test.describe('BrowserPangu', () => {
       await page.evaluate(() => {
         const elements = document.getElementsByClassName('e2');
         for (const element of elements) {
-          pangu.spacingNode(element);
+          pangu.spaceNode(element);
         }
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
@@ -452,7 +452,7 @@ test.describe('BrowserPangu', () => {
       await page.evaluate(() => {
         const elements = document.getElementsByClassName('e4');
         for (const element of elements) {
-          pangu.spacingNode(element);
+          pangu.spaceNode(element);
         }
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
@@ -467,7 +467,7 @@ test.describe('BrowserPangu', () => {
       await page.evaluate(() => {
         const elements = document.getElementsByClassName('e5');
         for (const element of elements) {
-          pangu.spacingNode(element);
+          pangu.spaceNode(element);
         }
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
@@ -475,7 +475,7 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('spacingNode() with getElementsByTagName', () => {
+  test.describe('spaceNode() with getElementsByTagName', () => {
     test('handle elements by tag name', async ({ page }) => {
       const htmlContent = loadFixture('tag-name.html');
       const expected = loadFixture('tag-name.expected.html').trim();
@@ -484,7 +484,7 @@ test.describe('BrowserPangu', () => {
       await page.evaluate(() => {
         const elements = document.getElementsByTagName('article');
         for (const element of elements) {
-          pangu.spacingNode(element);
+          pangu.spaceNode(element);
         }
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
@@ -492,13 +492,13 @@ test.describe('BrowserPangu', () => {
     });
   });
 
-  test.describe('spacingNode() with querySelector()', () => {
+  test.describe('spaceNode() with querySelector()', () => {
     test('handle page title', async ({ page }) => {
       await page.evaluate(() => {
         document.title = "Mr.龍島主道：「Let's Party!各位高明博雅君子！」";
         const titleElement = document.querySelector('head > title');
         if (titleElement) {
-          pangu.spacingNode(titleElement);
+          pangu.spaceNode(titleElement);
         }
       });
 
@@ -512,14 +512,14 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
     });
   });
 
-  test.describe('spacingPage()', () => {
+  test.describe('spacePage()', () => {
     test('handle entire page (title and body)', async ({ page }) => {
       const htmlContent = loadFixture('body.html');
       const expected = loadFixture('body.expected.html').trim();
@@ -527,7 +527,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent(htmlContent);
       await page.evaluate(() => {
         document.title = '花學姊的梅杜莎';
-        pangu.spacingPage();
+        pangu.spacePage();
       });
 
       const title = await page.title();
@@ -545,7 +545,7 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
@@ -555,7 +555,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent(`<div id="test"><h2 class="bgr6M8LczKBmaAn4sO0X UlmxiRo0duAvtZZW__30 zW32yWxwexOf03jBk4S7" id=":r31s:">Remove '铁蕾' from 1 Folder?</h2></div>`);
       const result = await page.evaluate(() => {
         const element = document.getElementById('test')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
       expect(result).toBe(`Remove '铁蕾' from 1 Folder?`);
@@ -564,7 +564,7 @@ test.describe('BrowserPangu', () => {
     test('handle contenteditable elements by skipping them', async ({ page }) => {
       await page.setContent('<div contenteditable="true">abc漢字1</div>');
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const content = await page.content();
       expect(content).toContain('<div contenteditable="true">abc漢字1</div>');
@@ -573,7 +573,7 @@ test.describe('BrowserPangu', () => {
     test('skip spacing inside elements with no-pangu-spacing class', async ({ page }) => {
       await page.setContent('<p>漢字<span class="no-pangu-spacing">abc漢字1</span>漢字</p>');
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const result = await page.evaluate(() => document.querySelector('p')!.innerHTML);
       // Text inside no-pangu-spacing should be untouched, but outer text nodes should still get spacing
@@ -584,7 +584,7 @@ test.describe('BrowserPangu', () => {
       // code tag is in ignoredTags - text inside should not be spaced
       await page.setContent('<p>漢字<code>abc漢字1</code>漢字</p>');
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const result = await page.evaluate(() => document.querySelector('p')!.innerHTML);
       expect(result).toContain('<code>abc漢字1</code>');
@@ -596,7 +596,7 @@ test.describe('BrowserPangu', () => {
     test.fixme('handle spacing around inline code elements', async ({ page }) => {
       await page.setContent('<p>中文<code>English</code>中文</p>');
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const result = await page.evaluate(() => document.querySelector('p')!.innerHTML);
       expect(result).toBe('中文 <code>English</code> 中文');
@@ -607,7 +607,7 @@ test.describe('BrowserPangu', () => {
       // This validates that the TreeWalker filter is sufficient without canIgnoreNode
       await page.setContent('<div>漢字abc<pre><code>漢字def</code></pre>漢字ghi</div>');
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
       const result = await page.evaluate(() => document.querySelector('div')!.innerHTML);
       // Text outside ignored containers gets spaced
@@ -622,7 +622,7 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
 
       // Check that input values are unchanged
@@ -646,7 +646,7 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
@@ -661,7 +661,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div id="test1"><span>社</span>"<span>DF</span></div>');
       const result1 = await page.evaluate(() => {
         const element = document.getElementById('test1')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
       expect(result1).toBe('社 "DF');
@@ -670,7 +670,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div id="test2">前面的文字"<span>中间的内容</span>"后面的文字</div>');
       const result2 = await page.evaluate(() => {
         const element = document.getElementById('test2')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
       expect(result2).toBe('前面的文字 "中间的内容" 后面的文字');
@@ -679,7 +679,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div id="test3">【UCG中字】"數毛社"DF的《戰神4》全新演示解析</div>');
       const result3 = await page.evaluate(() => {
         const element = document.getElementById('test3')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
       expect(result3).toBe('【UCG 中字】"數毛社" DF 的《戰神 4》全新演示解析');
@@ -705,7 +705,7 @@ test.describe('BrowserPangu', () => {
       );
 
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
@@ -727,7 +727,7 @@ test.describe('BrowserPangu', () => {
 
       const afterText = await page.evaluate(() => {
         const element = document.getElementById('test')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
 
@@ -753,7 +753,7 @@ test.describe('BrowserPangu', () => {
 
       await page.evaluate(() => {
         const element = document.getElementById('test')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
       });
 
       const result = await page.evaluate(() => document.getElementById('test')!.textContent);
@@ -769,7 +769,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent(`<div id="test1">${properlySpacedText}</div>`);
       const result1 = await page.evaluate(() => {
         const element = document.getElementById('test1')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
         return element.textContent;
       });
       expect(result1).toBe(properlySpacedText);
@@ -783,7 +783,7 @@ test.describe('BrowserPangu', () => {
         div.appendChild(document.createTextNode(' EAS'));
         div.appendChild(document.createTextNode('  build')); // Double space at start
 
-        pangu.spacingNode(div);
+        pangu.spaceNode(div);
         return div.textContent;
       });
       expect(result2).not.toContain('   ');
@@ -798,7 +798,7 @@ test.describe('BrowserPangu', () => {
 
       // Apply spacing
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       // Check that we don't add extra space inside the second span
@@ -846,7 +846,7 @@ test.describe('BrowserPangu', () => {
         await page.setContent(testCase.html);
 
         await page.evaluate(() => {
-          pangu.spacingNode(document.body);
+          pangu.spaceNode(document.body);
         });
 
         // Check that the second span content remains unchanged (no space added)
@@ -871,7 +871,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div><span>測試</span><span>文字</span></div>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       // Currently this doesn't work as expected - no space is added
@@ -888,7 +888,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<div>測試<span>文字</span></div>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       const withSpaceResult = await page.evaluate(() => {
@@ -908,7 +908,7 @@ test.describe('BrowserPangu', () => {
 
       await page.evaluate(() => {
         const element = document.getElementById('grid-container')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
       });
 
       const panguCount = await page.evaluate(() => document.querySelectorAll('pangu').length);
@@ -924,7 +924,7 @@ test.describe('BrowserPangu', () => {
 
       await page.evaluate(() => {
         const element = document.getElementById('flex-container')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
       });
 
       const panguCount = await page.evaluate(() => document.querySelectorAll('pangu').length);
@@ -942,7 +942,7 @@ test.describe('BrowserPangu', () => {
       `);
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       const panguCount = await page.evaluate(() => document.querySelectorAll('pangu').length);
@@ -955,7 +955,7 @@ test.describe('BrowserPangu', () => {
 
       await page.evaluate(() => {
         const element = document.getElementById('normal')!;
-        pangu.spacingNode(element);
+        pangu.spaceNode(element);
       });
 
       const panguCount = await page.evaluate(() => document.querySelectorAll('pangu').length);
@@ -976,7 +976,7 @@ test.describe('BrowserPangu', () => {
           '<p id="centeredDiv"><span style="color: #000000;"><strong>優惠方案：</strong>影劇館<sup>+</sup>收視費用為月繳費用，不含HiNet光世代及MOD平臺服務等費用</span></p>',
       );
 
-      await page.evaluate(() => pangu.spacingPage());
+      await page.evaluate(() => pangu.spacePage());
 
       expect(await page.locator('#exact').innerHTML()).toBe('<span style="color: #ff874d;">影劇館<sup>+</sup></span>');
       expect(await page.locator('#following').innerHTML()).toBe('<span>影劇館<sup>+</sup> 中文</span>');
@@ -997,7 +997,7 @@ test.describe('BrowserPangu', () => {
           '<div id="following"><span>影劇館<sup>+</sup><a>中文</a></span></div>',
       );
 
-      await page.evaluate(() => pangu.spacingPage());
+      await page.evaluate(() => pangu.spacePage());
 
       expect(await page.locator('#footnote').innerHTML()).toBe('<span>中文<sup><a>1</a></sup> 中文</span>');
       expect(await page.locator('#preceding').innerHTML()).toBe('<a>中文</a><sup>1</sup> 中文');
@@ -1008,7 +1008,7 @@ test.describe('BrowserPangu', () => {
     test('should preserve author spaces around superscript', async ({ page }) => {
       await page.setContent('<div id="before">影劇館 <sup>+</sup></div><div id="inside">影劇館<sup> +</sup></div><div id="after">影劇館<sup>+</sup> CJK</div>');
 
-      await page.evaluate(() => pangu.spacingPage());
+      await page.evaluate(() => pangu.spacePage());
 
       expect(await page.locator('#before').innerHTML()).toBe('影劇館 <sup>+</sup>');
       expect(await page.locator('#inside').innerHTML()).toBe('影劇館<sup> +</sup>');
@@ -1021,7 +1021,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test">字<span><a href="#">x</a></span> tail</p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const result = await page.evaluate(() => document.getElementById('test')!.textContent);
@@ -1032,7 +1032,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test"><a href="#">字</a> <b>x</b></p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const html = await page.evaluate(() => document.getElementById('test')!.innerHTML);
@@ -1045,7 +1045,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test"><span><a href="#">字</a></span>\n<b>x</b></p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const result = await page.evaluate(() => document.querySelector('#test b')!.textContent);
@@ -1056,7 +1056,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test"><span><a href="#">字</a></span>x</p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const result = await page.evaluate(() => document.getElementById('test')!.textContent);
@@ -1068,7 +1068,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test">甲<span> </span>abc</p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const html = await page.evaluate(() => document.getElementById('test')!.innerHTML);
@@ -1079,7 +1079,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test">字<span><em> </em></span>x</p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const html = await page.evaluate(() => document.getElementById('test')!.innerHTML);
@@ -1091,7 +1091,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<p id="test">字<code>a b</code>x</p>');
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.getElementById('test')!);
+        pangu.spaceNode(document.getElementById('test')!);
       });
 
       const html = await page.evaluate(() => document.getElementById('test')!.innerHTML);
@@ -1106,7 +1106,7 @@ test.describe('BrowserPangu', () => {
       </div>`);
 
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
 
       const paragraphs = await page.evaluate(() => Array.from(document.querySelectorAll('p'), (p) => p.textContent));
@@ -1124,7 +1124,7 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
@@ -1139,7 +1139,7 @@ test.describe('BrowserPangu', () => {
 
       await page.setContent(htmlContent);
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
       const actual = await page.evaluate(() => document.body.innerHTML.trim());
       expect(actual).toBe(expected);
@@ -1151,7 +1151,7 @@ test.describe('BrowserPangu', () => {
       await page.setContent('<li>贼喊捉贼：Anthropic 自己的所有模型内容，<wbr>其实都是从全人类的知识以及相当多的版权内容上蒸馏/<wbr>训练出来的，现在他们却不允许其他人来蒸馏自己的模型。</li>');
 
       await page.evaluate(() => {
-        pangu.spacingPage();
+        pangu.spacePage();
       });
 
       const result = await page.evaluate(() => document.querySelector('li')!.textContent);
@@ -1176,7 +1176,7 @@ test.describe('BrowserPangu', () => {
       `);
 
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       // No <pangu> should be inserted between grid items
@@ -1218,7 +1218,7 @@ test.describe('BrowserPangu', () => {
 
       // Apply spacing
       await page.evaluate(() => {
-        pangu.spacingNode(document.body);
+        pangu.spaceNode(document.body);
       });
 
       // Check what the visible text looks like AFTER spacing

--- a/tests/browser/task-scheduler.playwright.ts
+++ b/tests/browser/task-scheduler.playwright.ts
@@ -41,7 +41,7 @@ test.describe('TaskScheduler Enabled', () => {
     const result = await page.evaluate(() => {
       pangu.taskScheduler.config.enabled = true;
 
-      pangu.spacingPage();
+      pangu.spacePage();
 
       // Since idle processing is async, we need to wait a bit
       return new Promise<{ finalText: string | null }>((resolve) => {
@@ -63,12 +63,12 @@ test.describe('TaskScheduler Enabled', () => {
   test('should process dynamic content asynchronously', async ({ page }) => {
     await page.evaluate(async () => {
       pangu.taskScheduler.config.enabled = true;
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 50, nodeMaxWaitMs: 100 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 50, nodeMaxWaitMs: 100 });
     });
 
     await page.waitForTimeout(50);
 
-    // Dynamically add content after autoSpacingPage is active
+    // Dynamically add content after autoSpacePage is active
     await page.evaluate(() => {
       const div = document.createElement('div');
       div.textContent = '小明在開發軟體時總是嚴格地遵循各項協定與標準，直到他看了ISO 3166-1';
@@ -87,7 +87,7 @@ test.describe('TaskScheduler Enabled', () => {
 
     const result = await page.evaluate(async () => {
       pangu.taskScheduler.config.enabled = true;
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 50, nodeMaxWaitMs: 100 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 50, nodeMaxWaitMs: 100 });
 
       const content = document.getElementById('content')!;
 
@@ -125,13 +125,13 @@ test.describe('TaskScheduler Enabled', () => {
 
       // Track how many times the observer processes mutations
       let processingCount = 0;
-      const originalSpacingNode = pangu.spacingNode.bind(pangu);
-      pangu.spacingNode = function (node: Node) {
+      const originalSpaceNode = pangu.spaceNode.bind(pangu);
+      pangu.spaceNode = function (node: Node) {
         processingCount++;
-        return originalSpacingNode(node);
+        return originalSpaceNode(node);
       };
 
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
 
       const content = document.getElementById('content')!;
       const div = document.createElement('div');
@@ -165,7 +165,7 @@ test.describe('TaskScheduler Enabled', () => {
     const result = await page.evaluate(async () => {
       pangu.taskScheduler.config.enabled = true;
 
-      pangu.spacingNode(document.getElementById('content')!);
+      pangu.spaceNode(document.getElementById('content')!);
 
       // Wait for idle processing
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -183,7 +183,7 @@ test.describe('TaskScheduler Enabled', () => {
       pangu.taskScheduler.config.enabled = true;
 
       // Large pageDelayMs keeps the initial page sweep out of the assertion window
-      pangu.autoSpacingPage({ pageDelayMs: 60000, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
+      pangu.autoSpacePage({ pageDelayMs: 60000, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
 
       // The two queued spans sandwich an untouched sibling, so their text nodes are not adjacent
       const container = document.getElementById('container')!;
@@ -212,7 +212,7 @@ test.describe('TaskScheduler Enabled', () => {
       pangu.taskScheduler.config.enabled = true;
 
       // Large pageDelayMs keeps the initial page sweep out of the assertion window
-      pangu.autoSpacingPage({ pageDelayMs: 60000, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
+      pangu.autoSpacePage({ pageDelayMs: 60000, nodeDelayMs: 100, nodeMaxWaitMs: 200 });
 
       // The two queued spans sandwich a wrapper whose whitespace already separates them
       const container = document.getElementById('container')!;
@@ -241,7 +241,7 @@ test.describe('TaskScheduler Enabled', () => {
 
       // Huge nodeDelayMs keeps the debounced queue path out of the assertion window:
       // only the pre-paint fast path can space anything below
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
 
       // Wait for the initial sweep's idle processing
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -267,7 +267,7 @@ test.describe('TaskScheduler Enabled', () => {
       pangu.taskScheduler.config.enabled = true;
 
       // Huge nodeDelayMs keeps the debounced queue path out of the assertion window
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
 
       // Wait for the initial sweep's idle processing
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -292,7 +292,7 @@ test.describe('TaskScheduler Enabled', () => {
       pangu.taskScheduler.config.enabled = true;
 
       // Huge nodeDelayMs keeps the debounced queue path out of the assertion window
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
 
       // Wait for the initial sweep's idle processing
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -316,7 +316,7 @@ test.describe('TaskScheduler Enabled', () => {
     const result = await page.evaluate(async () => {
       pangu.taskScheduler.config.enabled = true;
 
-      pangu.autoSpacingPage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
+      pangu.autoSpacePage({ pageDelayMs: 0, nodeDelayMs: 60000, nodeMaxWaitMs: 120000 });
       await new Promise((resolve) => setTimeout(resolve, 300));
 
       const content = document.getElementById('content')!;
@@ -347,7 +347,7 @@ test.describe('TaskScheduler Enabled', () => {
       pangu.taskScheduler.queue.add(() => {
         throw new Error('boom');
       });
-      pangu.spacingNode(document.getElementById('content')!);
+      pangu.spaceNode(document.getElementById('content')!);
 
       // Wait for idle processing
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -373,7 +373,7 @@ test.describe('TaskScheduler Fallback', () => {
       Object.defineProperty(window, 'requestIdleCallback', { value: undefined, configurable: true });
       pangu.taskScheduler.config.enabled = true;
 
-      pangu.spacingNode(document.getElementById('content')!);
+      pangu.spaceNode(document.getElementById('content')!);
 
       // No waiting: spacing must have completed synchronously
       return document.getElementById('content')!.textContent;

--- a/tests/browser/text-nodes-settled.playwright.ts
+++ b/tests/browser/text-nodes-settled.playwright.ts
@@ -17,7 +17,7 @@ function collectSettledTextNodes(page: Page) {
       window.__batchCount++;
       window.__settledTextNodes.push(...settledTextNodes.map(({ unspaced, settled }) => ({ unspaced, settled })));
     };
-    pangu.spacingNode(document.body);
+    pangu.spaceNode(document.body);
     return window.__settledTextNodes;
   });
 }
@@ -39,7 +39,7 @@ test.describe('onTextNodesSettled', () => {
 
     const result = await page.evaluate(() => {
       const unassigned = pangu.onTextNodesSettled === null;
-      pangu.spacingNode(document.body);
+      pangu.spaceNode(document.body);
       return { unassigned, text: document.body.textContent, captured: window.__settledTextNodes.length };
     });
 
@@ -55,7 +55,7 @@ test.describe('onTextNodesSettled', () => {
   });
 
   test('settle a text node a junction space wrote to after its own text spacing ran', async ({ page }) => {
-    // Boundary spacing prepends a space to a node text spacing already visited, so its settled text is not what spacingText() alone gave. The list is in reverse document order, so the second
+    // Boundary spacing prepends a space to a node text spacing already visited, so its settled text is not what spaceText() alone gave. The list is in reverse document order, so the second
     // node settles first. The unchanged node is in the list too: nothing is filtered here
     await page.setContent('<div><b>abc</b><span>氣溫是-5度</span></div>');
 

--- a/tests/browser/visibility-detector.playwright.ts
+++ b/tests/browser/visibility-detector.playwright.ts
@@ -76,7 +76,7 @@ test.describe('Visibility Detector', () => {
       `;
 
       // Process with visibility-aware spacing (synchronous)
-      pangu.spacingPage();
+      pangu.spacePage();
 
       const hiddenSpan = content.querySelector('.sr-only')!;
       const visibleSpan = content.querySelector('span:not(.sr-only)')!;
@@ -119,7 +119,7 @@ test.describe('Visibility Detector', () => {
 
       // Process with both visibility checking and async task scheduling
       // Use minimal delays for testing
-      pangu.autoSpacingPage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
+      pangu.autoSpacePage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
     });
 
     // Spacing lands in an idle callback, which a loaded CI box can starve for
@@ -156,7 +156,7 @@ test.describe('Visibility Detector', () => {
       `;
 
       // Process with visibility checking enabled (synchronous)
-      pangu.spacingPage();
+      pangu.spacePage();
 
       const spans = content.querySelectorAll('span');
 
@@ -196,7 +196,7 @@ test.describe('Visibility Detector', () => {
       `;
 
       // Process with visibility checking (synchronous)
-      pangu.spacingPage();
+      pangu.spacePage();
 
       // Get the spans we actually want by text content to avoid selector issues
       const allDivs = content.querySelectorAll('div');
@@ -227,16 +227,16 @@ test.describe('Visibility Detector', () => {
     expect(result.nestedStartsWithSpace).toBe(false);
   });
 
-  test.skip('should reproduce Google Calendar with autoSpacingPage - with MutationObserver', async ({ page }) => {
-    // This test simulates what happens when content is dynamically added after autoSpacingPage is started
+  test.skip('should reproduce Google Calendar with autoSpacePage - with MutationObserver', async ({ page }) => {
+    // This test simulates what happens when content is dynamically added after autoSpacePage is started
     await page.setContent('<div id="content"></div>');
 
     const results = await page.evaluate(async () => {
       const content = document.getElementById('content')!;
 
-      // Start autoSpacingPage FIRST, then add content
+      // Start autoSpacePage FIRST, then add content
       pangu.taskScheduler.config.enabled = true;
-      pangu.autoSpacingPage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
+      pangu.autoSpacePage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
 
       // Wait for autoSpacing to initialize
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -280,13 +280,13 @@ test.describe('Visibility Detector', () => {
     expect(results.startsWithSpace).toBe(false);
   });
 
-  test('should reproduce Google Calendar with autoSpacingPage', async ({ page }) => {
+  test('should reproduce Google Calendar with autoSpacePage', async ({ page }) => {
     await page.setContent('<div id="content"></div>');
 
     const results = await page.evaluate(async () => {
       const content = document.getElementById('content')!;
 
-      // Test both cases with autoSpacingPage
+      // Test both cases with autoSpacePage
       pangu.taskScheduler.config.enabled = true;
 
       // Case 2: Complex content with links (testing this first)
@@ -313,9 +313,9 @@ test.describe('Visibility Detector', () => {
     發布新版本到測試環境</span></div>
       `;
 
-      // Use autoSpacingPage instead of spacingPage
-      pangu.autoSpacingPage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
-      await new Promise((resolve) => setTimeout(resolve, 200)); // Wait longer for autoSpacingPage
+      // Use autoSpacePage instead of spacePage
+      pangu.autoSpacePage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
+      await new Promise((resolve) => setTimeout(resolve, 200)); // Wait longer for autoSpacePage
 
       const result = content.querySelector('span:not(.XuJrye)')!.textContent;
 
@@ -356,7 +356,7 @@ test.describe('Visibility Detector', () => {
     記得更新測試案例的預期結果</span></div>
       `;
 
-      pangu.spacingPage();
+      pangu.spacePage();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       const case1Result = content.querySelector('span:not(.XuJrye)')!.textContent;
@@ -385,7 +385,7 @@ test.describe('Visibility Detector', () => {
     發布新版本到測試環境</span></div>
       `;
 
-      pangu.spacingPage();
+      pangu.spacePage();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       const case2Result = content.querySelector('span:not(.XuJrye)')!.textContent;
@@ -440,7 +440,7 @@ test.describe('Visibility Detector', () => {
       // Test 1: Synchronous mode (should work correctly)
       pangu.taskScheduler.config.enabled = false;
 
-      pangu.spacingPage();
+      pangu.spacePage();
 
       const syncResult = content.querySelector('span:not(.XuJrye)')!.textContent;
 
@@ -466,7 +466,7 @@ test.describe('Visibility Detector', () => {
       // Test 2: Async mode with taskScheduler
       pangu.taskScheduler.config.enabled = true;
 
-      pangu.spacingPage();
+      pangu.spacePage();
 
       // Wait for async processing
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -549,7 +549,7 @@ test.describe('Visibility Detector', () => {
       pangu.taskScheduler.config.enabled = true;
 
       // Process the page
-      pangu.spacingPage();
+      pangu.spacePage();
 
       // Wait for async processing
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/tests/browser/visibility-detector.playwright.ts
+++ b/tests/browser/visibility-detector.playwright.ts
@@ -238,7 +238,7 @@ test.describe('Visibility Detector', () => {
       pangu.taskScheduler.config.enabled = true;
       pangu.autoSpacePage({ pageDelayMs: 10, nodeDelayMs: 10, nodeMaxWaitMs: 50 });
 
-      // Wait for autoSpacing to initialize
+      // Wait for autoSpacePage() to initialize
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // NOW add the content (simulating dynamic content loading)

--- a/tests/extension/ai-spacing.test.ts
+++ b/tests/extension/ai-spacing.test.ts
@@ -18,14 +18,14 @@ async function loadAiSpacing() {
   const sendMessage = vi.fn(({ kind, candidates }: ClassifyCandidatesMessage) => handleClassification(kind, candidates));
   vi.stubGlobal('chrome', { runtime: { sendMessage } });
   const { applyAiSpacing, warmUpAiSpacing } = await import('../../browser-extensions/chrome/src/ai-spacing/content-script');
-  async function spacingTextWithAi(unspaced: string) {
-    const settled = corePangu.spacingText(unspaced);
+  async function spaceTextWithAi(unspaced: string) {
+    const settled = corePangu.spaceText(unspaced);
     const node = { data: settled } as Text;
     await applyAiSpacing([{ node, unspaced, settled }]);
     return node.data;
   }
 
-  return { pangu, sendMessage, applyAiSpacing, warmUpAiSpacing, handleClassification, spacingTextWithAi };
+  return { pangu, sendMessage, applyAiSpacing, warmUpAiSpacing, handleClassification, spaceTextWithAi };
 }
 
 afterEach(() => {
@@ -36,54 +36,54 @@ describe('AI spacing results', () => {
   it('joins negative signs when the model answers signed-number', async () => {
     const clone = async () => ({ prompt: async () => '"signed-number"', destroy: vi.fn() });
     vi.stubGlobal('LanguageModel', { params: vi.fn(), availability: async () => 'available', create: async () => ({ clone }) });
-    const { spacingTextWithAi } = await loadAiSpacing();
+    const { spaceTextWithAi } = await loadAiSpacing();
 
-    expect(await spacingTextWithAi('氣溫是-5度左右')).toBe('氣溫是 -5 度左右');
-    expect(await spacingTextWithAi('從-5到-3度')).toBe('從 -5 到 -3 度');
-    expect(await spacingTextWithAi('Nasdaq-100本週下跌-13.44%')).toBe('Nasdaq-100 本週下跌 -13.44%');
-    expect(await spacingTextWithAi('公視+上架了新片，氣溫是-5度')).toBe('公視+ 上架了新片，氣溫是 -5 度');
+    expect(await spaceTextWithAi('氣溫是-5度左右')).toBe('氣溫是 -5 度左右');
+    expect(await spaceTextWithAi('從-5到-3度')).toBe('從 -5 到 -3 度');
+    expect(await spaceTextWithAi('Nasdaq-100本週下跌-13.44%')).toBe('Nasdaq-100 本週下跌 -13.44%');
+    expect(await spaceTextWithAi('公視+上架了新片，氣溫是-5度')).toBe('公視+ 上架了新片，氣溫是 -5 度');
   });
 
   it('keeps separators and uncertain readings spaced', async () => {
     const prompt = vi.fn().mockResolvedValueOnce('"range-or-separator"').mockResolvedValueOnce('"unsure"');
     const clone = async () => ({ prompt, destroy: vi.fn() });
     vi.stubGlobal('LanguageModel', { params: vi.fn(), availability: async () => 'available', create: async () => ({ clone }) });
-    const { spacingTextWithAi } = await loadAiSpacing();
+    const { spaceTextWithAi } = await loadAiSpacing();
 
-    expect(await spacingTextWithAi('早鳥票-2張')).toBe('早鳥票 - 2 張');
-    expect(await spacingTextWithAi('未知-4')).toBe('未知 - 4');
+    expect(await spaceTextWithAi('早鳥票-2張')).toBe('早鳥票 - 2 張');
+    expect(await spaceTextWithAi('未知-4')).toBe('未知 - 4');
     expect(prompt).toHaveBeenCalledTimes(2);
   });
 
   it('restores name suffixes without a model', async () => {
     vi.stubGlobal('LanguageModel', undefined);
-    const { spacingTextWithAi, sendMessage } = await loadAiSpacing();
+    const { spaceTextWithAi, sendMessage } = await loadAiSpacing();
 
-    expect(await spacingTextWithAi('Disney+上架了新片')).toBe('Disney+ 上架了新片');
-    expect(await spacingTextWithAi('公視+上架了新片')).toBe('公視+ 上架了新片');
-    expect(await spacingTextWithAi('如何使用PTS+（公視+）註冊與觀看？')).toBe('如何使用 PTS+（公視+）註冊與觀看？');
-    expect(await spacingTextWithAi('MOD+影劇館+上架')).toBe('MOD + 影劇館+ 上架');
-    expect(await spacingTextWithAi('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV+ 等串流平台');
-    expect(await spacingTextWithAi('影劇館+/全選')).toBe('影劇館+/全選');
-    expect(await spacingTextWithAi('公視+(免費平台)')).toBe('公視+ (免費平台)');
-    expect(await spacingTextWithAi('「公視+」')).toBe('「公視+」');
-    expect(await spacingTextWithAi('今天來看公視+')).toBe('今天來看公視+');
-    expect(await spacingTextWithAi('vivo X70 Pro+開賣')).toBe('vivo X70 Pro+ 開賣');
-    expect(await spacingTextWithAi('評等介於AA-和AA+之間')).toBe('評等介於 AA- 和 AA+ 之間');
-    expect(await spacingTextWithAi('血型是AB-的人')).toBe('血型是 AB- 的人');
+    expect(await spaceTextWithAi('Disney+上架了新片')).toBe('Disney+ 上架了新片');
+    expect(await spaceTextWithAi('公視+上架了新片')).toBe('公視+ 上架了新片');
+    expect(await spaceTextWithAi('如何使用PTS+（公視+）註冊與觀看？')).toBe('如何使用 PTS+（公視+）註冊與觀看？');
+    expect(await spaceTextWithAi('MOD+影劇館+上架')).toBe('MOD + 影劇館+ 上架');
+    expect(await spaceTextWithAi('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV+ 等串流平台');
+    expect(await spaceTextWithAi('影劇館+/全選')).toBe('影劇館+/全選');
+    expect(await spaceTextWithAi('公視+(免費平台)')).toBe('公視+ (免費平台)');
+    expect(await spaceTextWithAi('「公視+」')).toBe('「公視+」');
+    expect(await spaceTextWithAi('今天來看公視+')).toBe('今天來看公視+');
+    expect(await spaceTextWithAi('vivo X70 Pro+開賣')).toBe('vivo X70 Pro+ 開賣');
+    expect(await spaceTextWithAi('評等介於AA-和AA+之間')).toBe('評等介於 AA- 和 AA+ 之間');
+    expect(await spaceTextWithAi('血型是AB-的人')).toBe('血型是 AB- 的人');
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it('preserves core spacing and author-written gaps without a model', async () => {
     vi.stubGlobal('LanguageModel', undefined);
-    const { spacingTextWithAi, sendMessage } = await loadAiSpacing();
+    const { spaceTextWithAi, sendMessage } = await loadAiSpacing();
 
-    expect(await spacingTextWithAi('打+886這個號碼')).toBe('打 +886 這個號碼');
-    expect(await spacingTextWithAi('Disney+上架了C++課程')).toBe('Disney+ 上架了 C++ 課程');
-    expect(await spacingTextWithAi('Disney+上架了A+B')).toBe('Disney+ 上架了 A + B');
-    expect(await spacingTextWithAi('Switch+健身環套組')).toBe('Switch + 健身環套組');
-    expect(await spacingTextWithAi('公視 +上架了新片')).toBe('公視 + 上架了新片');
-    expect(await spacingTextWithAi('氣溫是 - 5度')).toBe('氣溫是 - 5 度');
+    expect(await spaceTextWithAi('打+886這個號碼')).toBe('打 +886 這個號碼');
+    expect(await spaceTextWithAi('Disney+上架了C++課程')).toBe('Disney+ 上架了 C++ 課程');
+    expect(await spaceTextWithAi('Disney+上架了A+B')).toBe('Disney+ 上架了 A + B');
+    expect(await spaceTextWithAi('Switch+健身環套組')).toBe('Switch + 健身環套組');
+    expect(await spaceTextWithAi('公視 +上架了新片')).toBe('公視 + 上架了新片');
+    expect(await spaceTextWithAi('氣溫是 - 5度')).toBe('氣溫是 - 5 度');
     expect(sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/extension/content-script.test.ts
+++ b/tests/extension/content-script.test.ts
@@ -9,9 +9,9 @@ vi.mock('../../browser-extensions/chrome/src/ai-spacing/content-script', () => a
 async function loadContentScript(settings: Settings | Promise<Settings>, url = 'https://docs.google.com/document/d/abc') {
   vi.resetModules();
   const pangu = {
-    autoSpacingPage: vi.fn(),
-    stopAutoSpacingPage: vi.fn(),
-    spacingPage: vi.fn(),
+    autoSpacePage: vi.fn(),
+    stopAutoSpacePage: vi.fn(),
+    spacePage: vi.fn(),
     onTextNodesSettled: null as ((nodes: SettledTextNode[]) => void) | null,
   };
   const addMessageListener = vi.fn<typeof chrome.runtime.onMessage.addListener>();
@@ -53,43 +53,43 @@ describe('manual spacing activation', () => {
     const manualResponse = vi.fn();
     expect(receiveMessage({ action: 'MANUAL_SPACING' }, {}, manualResponse)).toBe(true);
     expect(manualResponse).not.toHaveBeenCalled();
-    expect(pangu.autoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.autoSpacePage).not.toHaveBeenCalled();
     const nodes: SettledTextNode[] = [{ node: {} as Text, unspaced: '公視+上架', settled: '公視 + 上架' }];
-    pangu.autoSpacingPage.mockImplementation(() => pangu.onTextNodesSettled?.(nodes));
+    pangu.autoSpacePage.mockImplementation(() => pangu.onTextNodesSettled?.(nodes));
 
     finishSettings({ ...DEFAULT_SETTINGS, spacing_mode: 'spacing_when_click' });
     await vi.waitFor(() => expect(manualResponse).toHaveBeenCalledWith({ success: true }));
     expect(aiSpacing.applyAiSpacing).toHaveBeenCalledWith(nodes);
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(1);
     expect(await click()).toEqual({ success: true });
     expect(aiSpacing.warmUpAiSpacing).toHaveBeenCalledTimes(2);
-    expect(pangu.spacingPage).not.toHaveBeenCalled();
+    expect(pangu.spacePage).not.toHaveBeenCalled();
   });
 
   it.each(['spacing_when_load', 'spacing_when_click'] as const)('starts on an excluded URL in %s without enabling disabled AI', async (spacing_mode) => {
     const { pangu, click } = await loadContentScript({ ...DEFAULT_SETTINGS, spacing_mode, is_ai_spacing_enabled: false });
-    expect(pangu.autoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.autoSpacePage).not.toHaveBeenCalled();
     expect(await click()).toEqual({ success: true });
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(1);
     expect(pangu.onTextNodesSettled).toBeNull();
     expect(aiSpacing.warmUpAiSpacing).not.toHaveBeenCalled();
-    expect(pangu.spacingPage).not.toHaveBeenCalled();
+    expect(pangu.spacePage).not.toHaveBeenCalled();
   });
 
   it('keeps manual activation on same-URL history updates but stops when the URL changes, even to an allowed URL', async () => {
     const url = 'https://example.com/';
     const { pangu, click, navigate } = await loadContentScript({ ...DEFAULT_SETTINGS, spacing_mode: 'spacing_when_click' }, url);
-    expect(pangu.autoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.autoSpacePage).not.toHaveBeenCalled();
     await click();
-    pangu.stopAutoSpacingPage.mockClear();
+    pangu.stopAutoSpacePage.mockClear();
 
     navigate(url);
-    expect(pangu.stopAutoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.stopAutoSpacePage).not.toHaveBeenCalled();
     navigate(`${url}#next`);
-    expect(pangu.stopAutoSpacingPage).toHaveBeenCalledTimes(1);
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.stopAutoSpacePage).toHaveBeenCalledTimes(1);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(1);
     await click();
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(2);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(2);
   });
 
   it('reports failed initialization instead of spacing before settings are available', async () => {
@@ -102,7 +102,7 @@ describe('manual spacing activation', () => {
     const response = click();
     failSettings(new Error('Storage is unavailable'));
     expect(await response).toEqual({ success: false });
-    expect(pangu.autoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.autoSpacePage).not.toHaveBeenCalled();
   });
 
   it('does not carry a pending manual click to a different URL', async () => {
@@ -115,13 +115,13 @@ describe('manual spacing activation', () => {
     location.href = 'https://example.com/next';
     finishSettings({ ...DEFAULT_SETTINGS, spacing_mode: 'spacing_when_click' });
     expect(await response).toEqual({ success: false });
-    expect(pangu.autoSpacingPage).not.toHaveBeenCalled();
+    expect(pangu.autoSpacePage).not.toHaveBeenCalled();
   });
 
   it('reports a failed manual start', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const { pangu, click } = await loadContentScript({ ...DEFAULT_SETTINGS, spacing_mode: 'spacing_when_click' });
-    pangu.autoSpacingPage.mockImplementation(() => {
+    pangu.autoSpacePage.mockImplementation(() => {
       throw new Error('Spacing failed');
     });
     expect(await click()).toEqual({ success: false });
@@ -131,20 +131,20 @@ describe('manual spacing activation', () => {
 describe('automatic spacing activation', () => {
   it('reapplies URL filters after a manual override', async () => {
     const { pangu, click, navigate } = await loadContentScript(DEFAULT_SETTINGS, 'https://example.com/');
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(1);
     expect(pangu.onTextNodesSettled).toBeTypeOf('function');
 
     const excludedUrl = 'https://docs.google.com/document/d/abc';
     navigate(excludedUrl);
-    expect(pangu.stopAutoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.stopAutoSpacePage).toHaveBeenCalledTimes(1);
     await click();
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(2);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(2);
     navigate(excludedUrl);
-    expect(pangu.stopAutoSpacingPage).toHaveBeenCalledTimes(1);
+    expect(pangu.stopAutoSpacePage).toHaveBeenCalledTimes(1);
     navigate(`${excludedUrl}?next`);
-    expect(pangu.stopAutoSpacingPage).toHaveBeenCalledTimes(2);
+    expect(pangu.stopAutoSpacePage).toHaveBeenCalledTimes(2);
     navigate('https://example.com/next');
-    expect(pangu.autoSpacingPage).toHaveBeenCalledTimes(3);
+    expect(pangu.autoSpacePage).toHaveBeenCalledTimes(3);
     expect(aiSpacing.warmUpAiSpacing).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/extension/urls.test.ts
+++ b/tests/extension/urls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_SETTINGS, type Settings } from '../../browser-extensions/chrome/src/settings/storage';
-import { isValidUrl, shouldAutoSpacing, shouldShowActiveStatus, shouldShowOffIcon } from '../../browser-extensions/chrome/src/settings/urls';
+import { isValidUrl, shouldAutoSpace, shouldShowActiveStatus, shouldShowOffIcon } from '../../browser-extensions/chrome/src/settings/urls';
 
 function makeSettings(overrides: Partial<Settings> = {}): Settings {
   return { ...DEFAULT_SETTINGS, ...overrides };
@@ -90,25 +90,25 @@ describe('shouldShowOffIcon', () => {
   });
 });
 
-describe('shouldAutoSpacing', () => {
+describe('shouldAutoSpace', () => {
   it('waits for a click in manual mode, regardless of URL filters', () => {
     const current = makeSettings({ spacing_mode: 'spacing_when_click' });
-    expect(shouldAutoSpacing(current, 'https://example.com/')).toBe(false);
-    expect(shouldAutoSpacing(current, 'https://docs.google.com/document/d/abc')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://example.com/')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://docs.google.com/document/d/abc')).toBe(false);
   });
 
   it('spaces pages not matching the blacklist', () => {
-    expect(shouldAutoSpacing(makeSettings(), 'https://github.com/vinta/pangu.js')).toBe(true);
+    expect(shouldAutoSpace(makeSettings(), 'https://github.com/vinta/pangu.js')).toBe(true);
   });
 
   it('stops on blacklisted pages', () => {
-    expect(shouldAutoSpacing(makeSettings(), 'https://github.com/vinta/pangu.js/issues/316')).toBe(false);
-    expect(shouldAutoSpacing(makeSettings(), 'https://github.com/vinta/pangu.js/blob/master/README.md')).toBe(false);
+    expect(shouldAutoSpace(makeSettings(), 'https://github.com/vinta/pangu.js/issues/316')).toBe(false);
+    expect(shouldAutoSpace(makeSettings(), 'https://github.com/vinta/pangu.js/blob/master/README.md')).toBe(false);
   });
 
   it('spaces only whitelisted pages in whitelist mode', () => {
     const current = makeSettings({ filter_mode: 'whitelist', whitelist: ['https://example.com/*'] });
-    expect(shouldAutoSpacing(current, 'https://example.com/foo')).toBe(true);
-    expect(shouldAutoSpacing(current, 'https://other.com/')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://example.com/foo')).toBe(true);
+    expect(shouldAutoSpace(current, 'https://other.com/')).toBe(false);
   });
 });

--- a/tests/node/imports.cjs.test.ts
+++ b/tests/node/imports.cjs.test.ts
@@ -11,19 +11,19 @@ describe('Node.js CommonJS imports', () => {
   it('handle direct require imports', () => {
     const pangu = require('../../dist/node/index.cjs') as NodeCjsModule;
 
-    expect(pangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(pangu.spaceText('Hello世界')).toBe('Hello 世界');
 
     // NodePangu is available as a property on pangu
     const anotherPangu = new pangu.NodePangu();
-    expect(anotherPangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(anotherPangu.spaceText('Hello世界')).toBe('Hello 世界');
   });
 
   it('handle destructured require imports', () => {
     const { NodePangu, pangu } = require('../../dist/node/index.cjs') as NodeCjsModule;
 
-    expect(pangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(pangu.spaceText('Hello世界')).toBe('Hello 世界');
 
     const anotherPangu = new NodePangu();
-    expect(anotherPangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(anotherPangu.spaceText('Hello世界')).toBe('Hello 世界');
   });
 });

--- a/tests/node/imports.esm.test.ts
+++ b/tests/node/imports.esm.test.ts
@@ -3,17 +3,17 @@ import pangu, { pangu as namedPangu, NodePangu } from '../../dist/node/index.js'
 
 describe('Node.js ESM imports', () => {
   it('handle default ESM imports', () => {
-    expect(pangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(pangu.spaceText('Hello世界')).toBe('Hello 世界');
 
     // In ESM, NodePangu is a named export, not a property of pangu
     const anotherPangu = new NodePangu();
-    expect(anotherPangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(anotherPangu.spaceText('Hello世界')).toBe('Hello 世界');
   });
 
   it('handle destructured ESM imports', () => {
-    expect(namedPangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(namedPangu.spaceText('Hello世界')).toBe('Hello 世界');
 
     const anotherPangu = new NodePangu();
-    expect(anotherPangu.spacingText('Hello世界')).toBe('Hello 世界');
+    expect(anotherPangu.spaceText('Hello世界')).toBe('Hello 世界');
   });
 });

--- a/tests/node/index.test.ts
+++ b/tests/node/index.test.ts
@@ -10,29 +10,29 @@ const __dirname = dirname(__filename);
 describe('NodePangu', () => {
   const fixtureDir = resolve(__dirname, '../../fixtures');
 
-  describe('spacingFile()', () => {
+  describe('spaceFile()', () => {
     it('handle text file asynchronously', async () => {
-      const data = await pangu.spacingFile(`${fixtureDir}/text-file.txt`);
+      const data = await pangu.spaceFile(`${fixtureDir}/text-file.txt`);
       const expected = readFileSync(`${fixtureDir}/text-file.expected.txt`, 'utf8');
       expect(data).toBe(expected);
     });
 
     it('handle text file without EOF newline asynchronously', async () => {
-      const data = await pangu.spacingFile(`${fixtureDir}/text-file-no-eof-newline.txt`);
+      const data = await pangu.spaceFile(`${fixtureDir}/text-file-no-eof-newline.txt`);
       const expected = readFileSync(`${fixtureDir}/text-file-no-eof-newline.expected.txt`, 'utf8');
       expect(data).toBe(expected);
     });
   });
 
-  describe('spacingFileSync()', () => {
+  describe('spaceFileSync()', () => {
     it('handle text file synchronously', () => {
-      const data = pangu.spacingFileSync(`${fixtureDir}/text-file.txt`);
+      const data = pangu.spaceFileSync(`${fixtureDir}/text-file.txt`);
       const expected = readFileSync(`${fixtureDir}/text-file.expected.txt`, 'utf8');
       expect(data).toBe(expected);
     });
 
     it('handle text file without EOF newline synchronously', () => {
-      const data = pangu.spacingFileSync(`${fixtureDir}/text-file-no-eof-newline.txt`);
+      const data = pangu.spaceFileSync(`${fixtureDir}/text-file-no-eof-newline.txt`);
       const expected = readFileSync(`${fixtureDir}/text-file-no-eof-newline.expected.txt`, 'utf8');
       expect(data).toBe(expected);
     });
@@ -49,22 +49,22 @@ describe('NodePangu', () => {
 
       it('preserve CRLF line endings', () => {
         writeFileSync(tempFile, '中文abc\r\n第二行ABC\r\n');
-        expect(pangu.spacingFileSync(tempFile)).toBe('中文 abc\r\n第二行 ABC\r\n');
+        expect(pangu.spaceFileSync(tempFile)).toBe('中文 abc\r\n第二行 ABC\r\n');
       });
 
       it('preserve lone CR line endings', () => {
         writeFileSync(tempFile, '中文abc\r尾行ABC\r');
-        expect(pangu.spacingFileSync(tempFile)).toBe('中文 abc\r尾行 ABC\r');
+        expect(pangu.spaceFileSync(tempFile)).toBe('中文 abc\r尾行 ABC\r');
       });
 
       it('preserve CRLF without EOF newline', () => {
         writeFileSync(tempFile, '中文abc\r\n尾行XYZ');
-        expect(pangu.spacingFileSync(tempFile)).toBe('中文 abc\r\n尾行 XYZ');
+        expect(pangu.spaceFileSync(tempFile)).toBe('中文 abc\r\n尾行 XYZ');
       });
 
       it('preserve trailing space before CRLF', () => {
         writeFileSync(tempFile, '字A\r\n空格 在行尾 \r\n');
-        expect(pangu.spacingFileSync(tempFile)).toBe('字 A\r\n空格 在行尾 \r\n');
+        expect(pangu.spaceFileSync(tempFile)).toBe('字 A\r\n空格 在行尾 \r\n');
       });
     });
   });

--- a/tests/shared/api.test.ts
+++ b/tests/shared/api.test.ts
@@ -5,7 +5,7 @@ const pangu = new Pangu();
 
 describe('API', () => {
   describe('spaceText()', () => {
-    it('spacing text', () => {
+    it('space text', () => {
       // prettier-ignore
       expect(pangu.spaceText('聽說Hadoop工程師睡不著的時候都會MapReduce羊'))
                          .toBe('聽說 Hadoop 工程師睡不著的時候都會 MapReduce 羊');
@@ -15,7 +15,7 @@ describe('API', () => {
                          .toBe('遇到了一個問題，決定用 thread 來解決，嗯，在現有我兩個問了題');
     });
 
-    it('spacing text is idempotent', () => {
+    it('space text is idempotent', () => {
       // Formatter contract: a second pass never changes the output, so format-then-check always passes
       for (const text of ['"字+"', '"字|"', '你好"字+"世界', '多行"字+"\n下行"字|"', '聽說Hadoop工程師睡不著的時候都會MapReduce羊']) {
         const once = pangu.spaceText(text);

--- a/tests/shared/api.test.ts
+++ b/tests/shared/api.test.ts
@@ -4,22 +4,22 @@ import { Pangu } from '../../dist/shared/index.js';
 const pangu = new Pangu();
 
 describe('API', () => {
-  describe('spacingText()', () => {
+  describe('spaceText()', () => {
     it('spacing text', () => {
       // prettier-ignore
-      expect(pangu.spacingText('聽說Hadoop工程師睡不著的時候都會MapReduce羊'))
+      expect(pangu.spaceText('聽說Hadoop工程師睡不著的時候都會MapReduce羊'))
                          .toBe('聽說 Hadoop 工程師睡不著的時候都會 MapReduce 羊');
 
       // prettier-ignore
-      expect(pangu.spacingText('遇到了一個問題，決定用 thread 來解決，嗯，在現有我兩個問了題'))
+      expect(pangu.spaceText('遇到了一個問題，決定用 thread 來解決，嗯，在現有我兩個問了題'))
                          .toBe('遇到了一個問題，決定用 thread 來解決，嗯，在現有我兩個問了題');
     });
 
     it('spacing text is idempotent', () => {
       // Formatter contract: a second pass never changes the output, so format-then-check always passes
       for (const text of ['"字+"', '"字|"', '你好"字+"世界', '多行"字+"\n下行"字|"', '聽說Hadoop工程師睡不著的時候都會MapReduce羊']) {
-        const once = pangu.spacingText(text);
-        expect(pangu.spacingText(once)).toBe(once);
+        const once = pangu.spaceText(text);
+        expect(pangu.spaceText(once)).toBe(once);
         expect(pangu.hasProperSpacing(once)).toBe(true);
       }
     });

--- a/tests/shared/cjk-alphabets-numbers.test.ts
+++ b/tests/shared/cjk-alphabets-numbers.test.ts
@@ -5,119 +5,119 @@ const pangu = new Pangu();
 
 describe('CJK A N', () => {
   it('handle short text', () => {
-    expect(pangu.spacingText('中a')).toBe('中 a');
-    expect(pangu.spacingText('a中')).toBe('a 中');
-    expect(pangu.spacingText('1中')).toBe('1 中');
-    expect(pangu.spacingText('中1')).toBe('中 1');
-    expect(pangu.spacingText('中a1')).toBe('中 a1');
-    expect(pangu.spacingText('a1中')).toBe('a1 中');
-    expect(pangu.spacingText('a中1')).toBe('a 中 1');
-    expect(pangu.spacingText('1中a')).toBe('1 中 a');
+    expect(pangu.spaceText('中a')).toBe('中 a');
+    expect(pangu.spaceText('a中')).toBe('a 中');
+    expect(pangu.spaceText('1中')).toBe('1 中');
+    expect(pangu.spaceText('中1')).toBe('中 1');
+    expect(pangu.spaceText('中a1')).toBe('中 a1');
+    expect(pangu.spaceText('a1中')).toBe('a1 中');
+    expect(pangu.spaceText('a中1')).toBe('a 中 1');
+    expect(pangu.spaceText('1中a')).toBe('1 中 a');
   });
 
   it('handle alphabets', () => {
-    expect(pangu.spacingText('中文abc')).toBe('中文 abc');
-    expect(pangu.spacingText('abc中文')).toBe('abc 中文');
+    expect(pangu.spaceText('中文abc')).toBe('中文 abc');
+    expect(pangu.spaceText('abc中文')).toBe('abc 中文');
   });
 
   it('handle numbers', () => {
-    expect(pangu.spacingText('中文123')).toBe('中文 123');
-    expect(pangu.spacingText('123中文')).toBe('123 中文');
+    expect(pangu.spaceText('中文123')).toBe('中文 123');
+    expect(pangu.spaceText('123中文')).toBe('123 中文');
   });
 
   // https://symbl.cc/en/unicode-table/#latin-1-supplement
   it('handle Latin-1 Supplement', () => {
-    expect(pangu.spacingText('中文Ø漢字')).toBe('中文 Ø 漢字');
-    expect(pangu.spacingText('中文 Ø 漢字')).toBe('中文 Ø 漢字');
+    expect(pangu.spaceText('中文Ø漢字')).toBe('中文 Ø 漢字');
+    expect(pangu.spaceText('中文 Ø 漢字')).toBe('中文 Ø 漢字');
   });
 
   // https://symbl.cc/en/unicode-table/#greek-coptic
   it('handle Greek and Coptic', () => {
-    expect(pangu.spacingText('中文β漢字')).toBe('中文 β 漢字');
-    expect(pangu.spacingText('中文 β 漢字')).toBe('中文 β 漢字');
-    expect(pangu.spacingText('我是α，我是Ω')).toBe('我是 α，我是 Ω');
+    expect(pangu.spaceText('中文β漢字')).toBe('中文 β 漢字');
+    expect(pangu.spaceText('中文 β 漢字')).toBe('中文 β 漢字');
+    expect(pangu.spaceText('我是α，我是Ω')).toBe('我是 α，我是 Ω');
   });
 
   // https://symbl.cc/en/unicode-table/#number-forms
   it('handle Number Forms', () => {
-    expect(pangu.spacingText('中文Ⅶ漢字')).toBe('中文 Ⅶ 漢字');
-    expect(pangu.spacingText('中文 Ⅶ 漢字')).toBe('中文 Ⅶ 漢字');
+    expect(pangu.spaceText('中文Ⅶ漢字')).toBe('中文 Ⅶ 漢字');
+    expect(pangu.spaceText('中文 Ⅶ 漢字')).toBe('中文 Ⅶ 漢字');
   });
 
   // https://symbl.cc/en/unicode-table/#letterlike-symbols
   it('handle Letterlike Symbols', () => {
-    expect(pangu.spacingText('今天123℃很熱')).toBe('今天 123℃ 很熱');
-    expect(pangu.spacingText('攝氏25℃到30℃之間')).toBe('攝氏 25℃ 到 30℃ 之間');
-    expect(pangu.spacingText('水溫98℉了')).toBe('水溫 98℉ 了');
-    expect(pangu.spacingText('5℃~10℃之間')).toBe('5℃~10℃ 之間');
-    expect(pangu.spacingText('溫度是℃單位')).toBe('溫度是 ℃ 單位');
-    expect(pangu.spacingText('第№5號')).toBe('第 №5 號');
-    expect(pangu.spacingText('電阻10Ω很小')).toBe('電阻 10Ω 很小'); // \u2126 OHM SIGN, not Greek \u03a9
-    expect(pangu.spacingText('中文ℝ漢字')).toBe('中文 ℝ 漢字');
-    expect(pangu.spacingText('中文 ℝ 漢字')).toBe('中文 ℝ 漢字');
-    expect(pangu.spacingText('符號ℓ表示長度')).toBe('符號 ℓ 表示長度');
-    expect(pangu.spacingText('資訊ℹ圖示')).toBe('資訊 ℹ 圖示');
-    expect(pangu.spacingText('估計℮500ml')).toBe('估計 ℮500ml');
+    expect(pangu.spaceText('今天123℃很熱')).toBe('今天 123℃ 很熱');
+    expect(pangu.spaceText('攝氏25℃到30℃之間')).toBe('攝氏 25℃ 到 30℃ 之間');
+    expect(pangu.spaceText('水溫98℉了')).toBe('水溫 98℉ 了');
+    expect(pangu.spaceText('5℃~10℃之間')).toBe('5℃~10℃ 之間');
+    expect(pangu.spaceText('溫度是℃單位')).toBe('溫度是 ℃ 單位');
+    expect(pangu.spaceText('第№5號')).toBe('第 №5 號');
+    expect(pangu.spaceText('電阻10Ω很小')).toBe('電阻 10Ω 很小'); // \u2126 OHM SIGN, not Greek \u03a9
+    expect(pangu.spaceText('中文ℝ漢字')).toBe('中文 ℝ 漢字');
+    expect(pangu.spaceText('中文 ℝ 漢字')).toBe('中文 ℝ 漢字');
+    expect(pangu.spaceText('符號ℓ表示長度')).toBe('符號 ℓ 表示長度');
+    expect(pangu.spaceText('資訊ℹ圖示')).toBe('資訊 ℹ 圖示');
+    expect(pangu.spaceText('估計℮500ml')).toBe('估計 ℮500ml');
   });
 
   // https://symbl.cc/en/unicode-table/#dingbats
   it('handle Dingbats symbols', () => {
-    expect(pangu.spacingText('剪刀✂符號')).toBe('剪刀 ✂ 符號');
-    expect(pangu.spacingText('完成✅了')).toBe('完成 ✅ 了');
-    expect(pangu.spacingText('愛心❤符號')).toBe('愛心 ❤ 符號');
+    expect(pangu.spaceText('剪刀✂符號')).toBe('剪刀 ✂ 符號');
+    expect(pangu.spaceText('完成✅了')).toBe('完成 ✅ 了');
+    expect(pangu.spaceText('愛心❤符號')).toBe('愛心 ❤ 符號');
   });
 
   // https://symbl.cc/en/unicode-table/#cjk-radicals-supplement
   it('handle CJK Radicals Supplement', () => {
-    expect(pangu.spacingText('abc⻤123')).toBe('abc ⻤ 123');
-    expect(pangu.spacingText('abc ⻤ 123')).toBe('abc ⻤ 123');
+    expect(pangu.spaceText('abc⻤123')).toBe('abc ⻤ 123');
+    expect(pangu.spaceText('abc ⻤ 123')).toBe('abc ⻤ 123');
   });
 
   // https://symbl.cc/en/unicode-table/#kangxi-radicals
   it('handle Kangxi Radicals', () => {
-    expect(pangu.spacingText('abc⾗123')).toBe('abc ⾗ 123');
-    expect(pangu.spacingText('abc ⾗ 123')).toBe('abc ⾗ 123');
+    expect(pangu.spaceText('abc⾗123')).toBe('abc ⾗ 123');
+    expect(pangu.spaceText('abc ⾗ 123')).toBe('abc ⾗ 123');
   });
 
   // https://symbl.cc/en/unicode-table/#hiragana
   it('handle Hiragana', () => {
-    expect(pangu.spacingText('abcあ123')).toBe('abc あ 123');
-    expect(pangu.spacingText('abc あ 123')).toBe('abc あ 123');
+    expect(pangu.spaceText('abcあ123')).toBe('abc あ 123');
+    expect(pangu.spaceText('abc あ 123')).toBe('abc あ 123');
   });
 
   // https://symbl.cc/en/unicode-table/#katakana
   it('handle Katakana', () => {
-    expect(pangu.spacingText('abcア123')).toBe('abc ア 123');
-    expect(pangu.spacingText('abc ア 123')).toBe('abc ア 123');
+    expect(pangu.spaceText('abcア123')).toBe('abc ア 123');
+    expect(pangu.spaceText('abc ア 123')).toBe('abc ア 123');
   });
 
   // https://symbl.cc/en/unicode-table/#bopomofo
   it('handle Bopomofo', () => {
-    expect(pangu.spacingText('abcㄅ123')).toBe('abc ㄅ 123');
-    expect(pangu.spacingText('abc ㄅ 123')).toBe('abc ㄅ 123');
+    expect(pangu.spaceText('abcㄅ123')).toBe('abc ㄅ 123');
+    expect(pangu.spaceText('abc ㄅ 123')).toBe('abc ㄅ 123');
   });
 
   // https://symbl.cc/en/unicode-table/#enclosed-cjk-letters-and-months
   it('handle Enclosed CJK Letters And Months', () => {
-    expect(pangu.spacingText('abc㈱123')).toBe('abc ㈱ 123');
-    expect(pangu.spacingText('abc ㈱ 123')).toBe('abc ㈱ 123');
+    expect(pangu.spaceText('abc㈱123')).toBe('abc ㈱ 123');
+    expect(pangu.spaceText('abc ㈱ 123')).toBe('abc ㈱ 123');
   });
 
   // https://symbl.cc/en/unicode-table/#cjk-unified-ideographs-extension-a
   it('handle CJK Unified Ideographs Extension-A', () => {
-    expect(pangu.spacingText('abc㐂123')).toBe('abc 㐂 123');
-    expect(pangu.spacingText('abc 㐂 123')).toBe('abc 㐂 123');
+    expect(pangu.spaceText('abc㐂123')).toBe('abc 㐂 123');
+    expect(pangu.spaceText('abc 㐂 123')).toBe('abc 㐂 123');
   });
 
   // https://symbl.cc/en/unicode-table/#cjk-unified-ideographs
   it('handle CJK Unified Ideographs', () => {
-    expect(pangu.spacingText('abc丁123')).toBe('abc 丁 123');
-    expect(pangu.spacingText('abc 丁 123')).toBe('abc 丁 123');
+    expect(pangu.spaceText('abc丁123')).toBe('abc 丁 123');
+    expect(pangu.spaceText('abc 丁 123')).toBe('abc 丁 123');
   });
 
   // https://symbl.cc/en/unicode-table/#cjk-compatibility-ideographs
   it('handle CJK Compatibility Ideographs', () => {
-    expect(pangu.spacingText('abc車123')).toBe('abc 車 123');
-    expect(pangu.spacingText('abc 車 123')).toBe('abc 車 123');
+    expect(pangu.spaceText('abc車123')).toBe('abc 車 123');
+    expect(pangu.spaceText('abc 車 123')).toBe('abc 車 123');
   });
 });

--- a/tests/shared/symbol-ampersand.test.ts
+++ b/tests/shared/symbol-ampersand.test.ts
@@ -5,22 +5,22 @@ const pangu = new Pangu();
 
 describe('Symbol &', () => {
   it('handle & symbol as operator', () => {
-    expect(pangu.spacingText('前面&後面')).toBe('前面 & 後面');
-    expect(pangu.spacingText('Vinta&陳上進')).toBe('Vinta & 陳上進');
-    expect(pangu.spacingText('陳上進&Vinta')).toBe('陳上進 & Vinta');
+    expect(pangu.spaceText('前面&後面')).toBe('前面 & 後面');
+    expect(pangu.spaceText('Vinta&陳上進')).toBe('Vinta & 陳上進');
+    expect(pangu.spaceText('陳上進&Vinta')).toBe('陳上進 & Vinta');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 & 後面')).toBe('前面 & 後面');
-    expect(pangu.spacingText('Vinta & Mollie')).toBe('Vinta & Mollie');
-    expect(pangu.spacingText('Vinta & 陳上進')).toBe('Vinta & 陳上進');
-    expect(pangu.spacingText('陳上進 & Vinta')).toBe('陳上進 & Vinta');
-    expect(pangu.spacingText('得到一個 A & B 的結果')).toBe('得到一個 A & B 的結果');
+    expect(pangu.spaceText('前面 & 後面')).toBe('前面 & 後面');
+    expect(pangu.spaceText('Vinta & Mollie')).toBe('Vinta & Mollie');
+    expect(pangu.spaceText('Vinta & 陳上進')).toBe('Vinta & 陳上進');
+    expect(pangu.spaceText('陳上進 & Vinta')).toBe('陳上進 & Vinta');
+    expect(pangu.spaceText('得到一個 A & B 的結果')).toBe('得到一個 A & B 的結果');
   });
 
   it('handle & symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta&Mollie')).toBe('Vinta&Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A&B的結果')).toBe('得到一個 A&B 的結果');
-    expect(pangu.spacingText('本週S&P 500及Nasdaq同時下跌')).toBe('本週 S&P 500 及 Nasdaq 同時下跌');
-    expect(pangu.spacingText('接下來是Q&A時間')).toBe('接下來是 Q&A 時間');
+    expect(pangu.spaceText('Vinta&Mollie')).toBe('Vinta&Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A&B的結果')).toBe('得到一個 A&B 的結果');
+    expect(pangu.spaceText('本週S&P 500及Nasdaq同時下跌')).toBe('本週 S&P 500 及 Nasdaq 同時下跌');
+    expect(pangu.spaceText('接下來是Q&A時間')).toBe('接下來是 Q&A 時間');
   });
 });

--- a/tests/shared/symbol-angle-brackets.test.ts
+++ b/tests/shared/symbol-angle-brackets.test.ts
@@ -5,63 +5,63 @@ const pangu = new Pangu();
 
 describe('Symbol < >', () => {
   it('handle < > symbols as angle brackets', () => {
-    expect(pangu.spacingText('前面<中文123漢字>後面')).toBe('前面 <中文 123 漢字> 後面');
-    expect(pangu.spacingText('前面<中文123>後面')).toBe('前面 <中文 123> 後面');
-    expect(pangu.spacingText('前面<123漢字>後面')).toBe('前面 <123 漢字> 後面');
-    expect(pangu.spacingText('前面<中文123> tail')).toBe('前面 <中文 123> tail');
-    expect(pangu.spacingText('head <中文123漢字>後面')).toBe('head <中文 123 漢字> 後面');
-    expect(pangu.spacingText('head <中文123漢字> tail')).toBe('head <中文 123 漢字> tail');
+    expect(pangu.spaceText('前面<中文123漢字>後面')).toBe('前面 <中文 123 漢字> 後面');
+    expect(pangu.spaceText('前面<中文123>後面')).toBe('前面 <中文 123> 後面');
+    expect(pangu.spaceText('前面<123漢字>後面')).toBe('前面 <123 漢字> 後面');
+    expect(pangu.spaceText('前面<中文123> tail')).toBe('前面 <中文 123> tail');
+    expect(pangu.spaceText('head <中文123漢字>後面')).toBe('head <中文 123 漢字> 後面');
+    expect(pangu.spaceText('head <中文123漢字> tail')).toBe('head <中文 123 漢字> tail');
   });
 
   it('handle < > symbols as HTML tags', () => {
-    expect(pangu.spacingText('<p>一行文本</p>')).toBe('<p>一行文本</p>');
-    expect(pangu.spacingText('<p>文字<strong>加粗</strong></p>')).toBe('<p>文字<strong>加粗</strong></p>');
-    expect(pangu.spacingText('<div>測試<span>內容</span>結束</div>')).toBe('<div>測試<span>內容</span>結束</div>');
-    expect(pangu.spacingText('<a href="#">連結</a>')).toBe('<a href="#">連結</a>');
-    expect(pangu.spacingText('<input value="測試123">')).toBe('<input value="測試 123">');
-    expect(pangu.spacingText('<img src="test.jpg" alt="測試圖片">')).toBe('<img src="test.jpg" alt="測試圖片">');
+    expect(pangu.spaceText('<p>一行文本</p>')).toBe('<p>一行文本</p>');
+    expect(pangu.spaceText('<p>文字<strong>加粗</strong></p>')).toBe('<p>文字<strong>加粗</strong></p>');
+    expect(pangu.spaceText('<div>測試<span>內容</span>結束</div>')).toBe('<div>測試<span>內容</span>結束</div>');
+    expect(pangu.spaceText('<a href="#">連結</a>')).toBe('<a href="#">連結</a>');
+    expect(pangu.spaceText('<input value="測試123">')).toBe('<input value="測試 123">');
+    expect(pangu.spaceText('<img src="test.jpg" alt="測試圖片">')).toBe('<img src="test.jpg" alt="測試圖片">');
 
     // Multiple tags
-    expect(pangu.spacingText('<p>第一段</p><p>第二段</p>')).toBe('<p>第一段</p><p>第二段</p>');
-    expect(pangu.spacingText('<h1>標題</h1><p>內容</p>')).toBe('<h1>標題</h1><p>內容</p>');
+    expect(pangu.spaceText('<p>第一段</p><p>第二段</p>')).toBe('<p>第一段</p><p>第二段</p>');
+    expect(pangu.spaceText('<h1>標題</h1><p>內容</p>')).toBe('<h1>標題</h1><p>內容</p>');
 
     // Nested tags
     // prettier-ignore
-    expect(pangu.spacingText('<div><p>嵌套<strong>測試</strong></p></div>'))
+    expect(pangu.spaceText('<div><p>嵌套<strong>測試</strong></p></div>'))
                        .toBe('<div><p>嵌套<strong>測試</strong></p></div>');
 
     // <br> or <hr> must stay untouched
-    expect(pangu.spacingText('文字<br>換行')).toBe('文字<br>換行');
-    expect(pangu.spacingText('文字<br />換行')).toBe('文字<br />換行');
-    expect(pangu.spacingText('第一段<hr>第二段')).toBe('第一段<hr>第二段');
-    expect(pangu.spacingText('第一段<hr />第二段')).toBe('第一段<hr />第二段');
+    expect(pangu.spaceText('文字<br>換行')).toBe('文字<br>換行');
+    expect(pangu.spaceText('文字<br />換行')).toBe('文字<br />換行');
+    expect(pangu.spaceText('第一段<hr>第二段')).toBe('第一段<hr>第二段');
+    expect(pangu.spaceText('第一段<hr />第二段')).toBe('第一段<hr />第二段');
 
     // Real-world markup stays untouched
-    expect(pangu.spacingText('<ul><li>第一項</li><li>第二項</li></ul>')).toBe('<ul><li>第一項</li><li>第二項</li></ul>');
-    expect(pangu.spacingText('<button disabled>送出表單</button>')).toBe('<button disabled>送出表單</button>');
-    expect(pangu.spacingText('<img src="photo.jpg">上面是圖片')).toBe('<img src="photo.jpg">上面是圖片');
+    expect(pangu.spaceText('<ul><li>第一項</li><li>第二項</li></ul>')).toBe('<ul><li>第一項</li><li>第二項</li></ul>');
+    expect(pangu.spaceText('<button disabled>送出表單</button>')).toBe('<button disabled>送出表單</button>');
+    expect(pangu.spaceText('<img src="photo.jpg">上面是圖片')).toBe('<img src="photo.jpg">上面是圖片');
 
     // prettier-ignore
-    expect(pangu.spacingText('<attackOnJava>那一天，人類終於回想起了，曾經一度被XML所支配的恐懼</attackOnJava> <!-- 進擊的Java -->'))
+    expect(pangu.spaceText('<attackOnJava>那一天，人類終於回想起了，曾經一度被XML所支配的恐懼</attackOnJava> <!-- 進擊的Java -->'))
                        .toBe('<attackOnJava>那一天，人類終於回想起了，曾經一度被 XML 所支配的恐懼</attackOnJava> <!-- 進擊的 Java -->');
   });
 
   it('handle < > symbols as tag mention', () => {
-    expect(pangu.spacingText('在這裡插入一個<div>標籤')).toBe('在這裡插入一個 <div> 標籤');
-    expect(pangu.spacingText('型別是List<String>的容器')).toBe('型別是 List<String> 的容器');
-    expect(pangu.spacingText('把文字包在<span>裡面')).toBe('把文字包在 <span> 裡面');
-    expect(pangu.spacingText('每個<li>代表一個列表項目')).toBe('每個 <li> 代表一個列表項目');
-    expect(pangu.spacingText('用<table>排版是過時的做法')).toBe('用 <table> 排版是過時的做法');
-    expect(pangu.spacingText('HTML的<head>放的是metadata')).toBe('HTML 的 <head> 放的是 metadata');
-    expect(pangu.spacingText('<html>是整份文件的根元素')).toBe('<html> 是整份文件的根元素');
-    expect(pangu.spacingText('這裡放<Spinner />元件')).toBe('這裡放 <Spinner /> 元件');
+    expect(pangu.spaceText('在這裡插入一個<div>標籤')).toBe('在這裡插入一個 <div> 標籤');
+    expect(pangu.spaceText('型別是List<String>的容器')).toBe('型別是 List<String> 的容器');
+    expect(pangu.spaceText('把文字包在<span>裡面')).toBe('把文字包在 <span> 裡面');
+    expect(pangu.spaceText('每個<li>代表一個列表項目')).toBe('每個 <li> 代表一個列表項目');
+    expect(pangu.spaceText('用<table>排版是過時的做法')).toBe('用 <table> 排版是過時的做法');
+    expect(pangu.spaceText('HTML的<head>放的是metadata')).toBe('HTML 的 <head> 放的是 metadata');
+    expect(pangu.spaceText('<html>是整份文件的根元素')).toBe('<html> 是整份文件的根元素');
+    expect(pangu.spaceText('這裡放<Spinner />元件')).toBe('這裡放 <Spinner /> 元件');
 
     // Generic type parameters read as tag mentions too
-    expect(pangu.spacingText('回傳Promise<string>就好')).toBe('回傳 Promise<string> 就好');
-    expect(pangu.spacingText('用Vec<u8>儲存位元組')).toBe('用 Vec<u8> 儲存位元組');
-    expect(pangu.spacingText('先引入<iostream>標頭檔')).toBe('先引入 <iostream> 標頭檔');
+    expect(pangu.spaceText('回傳Promise<string>就好')).toBe('回傳 Promise<string> 就好');
+    expect(pangu.spaceText('用Vec<u8>儲存位元組')).toBe('用 Vec<u8> 儲存位元組');
+    expect(pangu.spaceText('先引入<iostream>標頭檔')).toBe('先引入 <iostream> 標頭檔');
 
     // A mention next to real markup: only the mention is spaced
-    expect(pangu.spacingText('<p>用<code>標記程式碼</p>')).toBe('<p>用 <code> 標記程式碼</p>');
+    expect(pangu.spaceText('<p>用<code>標記程式碼</p>')).toBe('<p>用 <code> 標記程式碼</p>');
   });
 });

--- a/tests/shared/symbol-asterisk.test.ts
+++ b/tests/shared/symbol-asterisk.test.ts
@@ -5,26 +5,26 @@ const pangu = new Pangu();
 
 describe('Symbol *', () => {
   it('handle * symbol as operator', () => {
-    expect(pangu.spacingText('前面*後面')).toBe('前面 * 後面');
-    expect(pangu.spacingText('Vinta*陳上進')).toBe('Vinta * 陳上進');
-    expect(pangu.spacingText('陳上進*Vinta')).toBe('陳上進 * Vinta');
-    expect(pangu.spacingText('標示*的欄位代表必填')).toBe('標示 * 的欄位代表必填');
+    expect(pangu.spaceText('前面*後面')).toBe('前面 * 後面');
+    expect(pangu.spaceText('Vinta*陳上進')).toBe('Vinta * 陳上進');
+    expect(pangu.spaceText('陳上進*Vinta')).toBe('陳上進 * Vinta');
+    expect(pangu.spaceText('標示*的欄位代表必填')).toBe('標示 * 的欄位代表必填');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 * 後面')).toBe('前面 * 後面');
-    expect(pangu.spacingText('Vinta * Mollie')).toBe('Vinta * Mollie');
-    expect(pangu.spacingText('Vinta * 陳上進')).toBe('Vinta * 陳上進');
-    expect(pangu.spacingText('陳上進 * Vinta')).toBe('陳上進 * Vinta');
-    expect(pangu.spacingText('得到一個 A * B 的結果')).toBe('得到一個 A * B 的結果');
+    expect(pangu.spaceText('前面 * 後面')).toBe('前面 * 後面');
+    expect(pangu.spaceText('Vinta * Mollie')).toBe('Vinta * Mollie');
+    expect(pangu.spaceText('Vinta * 陳上進')).toBe('Vinta * 陳上進');
+    expect(pangu.spaceText('陳上進 * Vinta')).toBe('陳上進 * Vinta');
+    expect(pangu.spaceText('得到一個 A * B 的結果')).toBe('得到一個 A * B 的結果');
   });
 
   it('handle * symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta*Mollie')).toBe('Vinta*Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A*B的結果')).toBe('得到一個 A*B 的結果');
-    expect(pangu.spacingText('算式是2*3的積')).toBe('算式是 2*3 的積');
+    expect(pangu.spaceText('Vinta*Mollie')).toBe('Vinta*Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A*B的結果')).toBe('得到一個 A*B 的結果');
+    expect(pangu.spaceText('算式是2*3的積')).toBe('算式是 2*3 的積');
   });
 
   it('handle * symbol as preserved pattern', () => {
-    expect(pangu.spacingText('刪掉*.log的檔案')).toBe('刪掉 *.log 的檔案');
+    expect(pangu.spaceText('刪掉*.log的檔案')).toBe('刪掉 *.log 的檔案');
   });
 });

--- a/tests/shared/symbol-at.test.ts
+++ b/tests/shared/symbol-at.test.ts
@@ -5,9 +5,9 @@ const pangu = new Pangu();
 
 describe('Symbol @', () => {
   it('handle @ symbol as at', () => {
-    expect(pangu.spacingText('前面@vinta後面')).toBe('前面 @vinta 後面');
-    expect(pangu.spacingText('前面@vinta_chen後面')).toBe('前面 @vinta_chen 後面');
-    expect(pangu.spacingText('前面@VintaChen後面')).toBe('前面 @VintaChen 後面');
-    expect(pangu.spacingText('前面@陳上進 後面')).toBe('前面 @陳上進 後面');
+    expect(pangu.spaceText('前面@vinta後面')).toBe('前面 @vinta 後面');
+    expect(pangu.spaceText('前面@vinta_chen後面')).toBe('前面 @vinta_chen 後面');
+    expect(pangu.spaceText('前面@VintaChen後面')).toBe('前面 @VintaChen 後面');
+    expect(pangu.spaceText('前面@陳上進 後面')).toBe('前面 @陳上進 後面');
   });
 });

--- a/tests/shared/symbol-backslash.test.ts
+++ b/tests/shared/symbol-backslash.test.ts
@@ -5,18 +5,18 @@ const pangu = new Pangu();
 
 describe('Symbol \\', () => {
   it('handle \\ symbol', () => {
-    expect(pangu.spacingText('前面\\後面')).toBe('前面 \\ 後面');
-    expect(pangu.spacingText('前面 \\ 後面')).toBe('前面 \\ 後面');
+    expect(pangu.spaceText('前面\\後面')).toBe('前面 \\ 後面');
+    expect(pangu.spaceText('前面 \\ 後面')).toBe('前面 \\ 後面');
   });
 
   it('handle \\ symbol as escape character', () => {
-    expect(pangu.spacingText('\\n')).toBe('\\n');
-    expect(pangu.spacingText('\\t')).toBe('\\t');
+    expect(pangu.spaceText('\\n')).toBe('\\n');
+    expect(pangu.spaceText('\\t')).toBe('\\t');
   });
 
   it('handle \\ symbol as Windows file path', () => {
-    expect(pangu.spacingText('檔案在C:\\Users\\name\\')).toBe('檔案在 C:\\Users\\name\\');
-    expect(pangu.spacingText('程式在D:\\Program Files\\')).toBe('程式在 D:\\Program Files\\');
-    expect(pangu.spacingText('在C:\\Windows\\System32')).toBe('在 C:\\Windows\\System32');
+    expect(pangu.spaceText('檔案在C:\\Users\\name\\')).toBe('檔案在 C:\\Users\\name\\');
+    expect(pangu.spaceText('程式在D:\\Program Files\\')).toBe('程式在 D:\\Program Files\\');
+    expect(pangu.spaceText('在C:\\Windows\\System32')).toBe('在 C:\\Windows\\System32');
   });
 });

--- a/tests/shared/symbol-backtick.test.ts
+++ b/tests/shared/symbol-backtick.test.ts
@@ -5,22 +5,22 @@ const pangu = new Pangu();
 
 describe('Symbol ` `', () => {
   it('handle ` ` symbols as quotes', () => {
-    expect(pangu.spacingText('前面`中間`後面')).toBe('前面 `中間` 後面');
+    expect(pangu.spaceText('前面`中間`後面')).toBe('前面 `中間` 後面');
 
     // prettier-ignore
-    expect(pangu.spacingText('`! git commit -a -m "蛤"`'))
+    expect(pangu.spaceText('`! git commit -a -m "蛤"`'))
                        .toBe('`! git commit -a -m "蛤"`');
 
     // prettier-ignore
-    expect(pangu.spacingText('从结果来看，当a.b销毁后，`a.getB()`返回值为null'))
+    expect(pangu.spaceText('从结果来看，当a.b销毁后，`a.getB()`返回值为null'))
                        .toBe('从结果来看，当 a.b 销毁后，`a.getB()` 返回值为 null');
 
     // prettier-ignore
-    expect(pangu.spacingText('雖然知道可以在Claude Code直接執行shell指令，例如`! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用`!`啊#TIL'))
+    expect(pangu.spaceText('雖然知道可以在Claude Code直接執行shell指令，例如`! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用`!`啊#TIL'))
                        .toBe('雖然知道可以在 Claude Code 直接執行 shell 指令，例如 `! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用 `!` 啊 #TIL');
 
     // prettier-ignore
-    expect(pangu.spacingText('雖然知道可以在 Claude Code 直接執行 shell 指令，例如 `! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用 `!` 啊 #TIL'))
+    expect(pangu.spaceText('雖然知道可以在 Claude Code 直接執行 shell 指令，例如 `! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用 `!` 啊 #TIL'))
                        .toBe('雖然知道可以在 Claude Code 直接執行 shell 指令，例如 `! git commit -a -m "蛤"`，但是看了文件才知道原來在 http://command.md 裡面也可以用 `!` 啊 #TIL');
   });
 });

--- a/tests/shared/symbol-caret.test.ts
+++ b/tests/shared/symbol-caret.test.ts
@@ -5,7 +5,7 @@ const pangu = new Pangu();
 
 describe('Symbol ^', () => {
   it('handle ^ symbol', () => {
-    expect(pangu.spacingText('前面^後面')).toBe('前面 ^ 後面');
-    expect(pangu.spacingText('前面 ^ 後面')).toBe('前面 ^ 後面');
+    expect(pangu.spaceText('前面^後面')).toBe('前面 ^ 後面');
+    expect(pangu.spaceText('前面 ^ 後面')).toBe('前面 ^ 後面');
   });
 });

--- a/tests/shared/symbol-colon.test.ts
+++ b/tests/shared/symbol-colon.test.ts
@@ -5,26 +5,26 @@ const pangu = new Pangu();
 
 describe('Symbol :', () => {
   it('handle : symbol', () => {
-    expect(pangu.spacingText('前面:後面')).toBe('前面: 後面');
-    expect(pangu.spacingText('電話:123456789')).toBe('電話: 123456789');
-    expect(pangu.spacingText('前面:I have no idea後面')).toBe('前面: I have no idea 後面');
+    expect(pangu.spaceText('前面:後面')).toBe('前面: 後面');
+    expect(pangu.spaceText('電話:123456789')).toBe('電話: 123456789');
+    expect(pangu.spaceText('前面:I have no idea後面')).toBe('前面: I have no idea 後面');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 : 後面')).toBe('前面 : 後面');
-    expect(pangu.spacingText('前面: 後面')).toBe('前面: 後面');
-    expect(pangu.spacingText('前面 :後面')).toBe('前面 :後面');
-    expect(pangu.spacingText('前面: I have no idea後面')).toBe('前面: I have no idea 後面');
+    expect(pangu.spaceText('前面 : 後面')).toBe('前面 : 後面');
+    expect(pangu.spaceText('前面: 後面')).toBe('前面: 後面');
+    expect(pangu.spaceText('前面 :後面')).toBe('前面 :後面');
+    expect(pangu.spaceText('前面: I have no idea後面')).toBe('前面: I have no idea 後面');
   });
 
   // FIXME
   it.todo('handle : symbol as emoticon', () => {
-    expect(pangu.spacingText('前面:)後面')).toBe('前面 :) 後面');
+    expect(pangu.spaceText('前面:)後面')).toBe('前面 :) 後面');
   });
 
   // FIXME
   it.todo('handle : symbol as separator', () => {
-    expect(pangu.spacingText('前面:後面:再後面')).toBe('前面:後面:再後面');
-    expect(pangu.spacingText('前面:後面:再後面:更後面')).toBe('前面:後面:再後面:更後面');
-    expect(pangu.spacingText('前面:後面:再後面:更後面:超後面')).toBe('前面:後面:再後面:更後面:超後面');
+    expect(pangu.spaceText('前面:後面:再後面')).toBe('前面:後面:再後面');
+    expect(pangu.spaceText('前面:後面:再後面:更後面')).toBe('前面:後面:再後面:更後面');
+    expect(pangu.spaceText('前面:後面:再後面:更後面:超後面')).toBe('前面:後面:再後面:更後面:超後面');
   });
 });

--- a/tests/shared/symbol-comma.test.ts
+++ b/tests/shared/symbol-comma.test.ts
@@ -5,17 +5,17 @@ const pangu = new Pangu();
 
 describe('Symbol ,', () => {
   it('handle , symbol', () => {
-    expect(pangu.spacingText('前面,後面')).toBe('前面, 後面');
+    expect(pangu.spaceText('前面,後面')).toBe('前面, 後面');
 
-    expect(pangu.spacingText('"你好",她說')).toBe('"你好", 她說');
-    expect(pangu.spacingText('每月只要1,000元')).toBe('每月只要 1,000 元');
-    expect(pangu.spacingText('精采5G購機方案(30個月),月繳599元購機優惠(30個月)')).toBe('精采 5G 購機方案 (30 個月), 月繳 599 元購機優惠 (30 個月)');
+    expect(pangu.spaceText('"你好",她說')).toBe('"你好", 她說');
+    expect(pangu.spaceText('每月只要1,000元')).toBe('每月只要 1,000 元');
+    expect(pangu.spaceText('精采5G購機方案(30個月),月繳599元購機優惠(30個月)')).toBe('精采 5G 購機方案 (30 個月), 月繳 599 元購機優惠 (30 個月)');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 , 後面')).toBe('前面 , 後面');
-    expect(pangu.spacingText('前面, 後面')).toBe('前面, 後面');
+    expect(pangu.spaceText('前面 , 後面')).toBe('前面 , 後面');
+    expect(pangu.spaceText('前面, 後面')).toBe('前面, 後面');
 
     // Rare cases, ignore
-    // expect(pangu.spacingText('前面 ,後面')).toBe('前面 ,後面');
+    // expect(pangu.spaceText('前面 ,後面')).toBe('前面 ,後面');
   });
 });

--- a/tests/shared/symbol-curly-brackets.test.ts
+++ b/tests/shared/symbol-curly-brackets.test.ts
@@ -5,16 +5,16 @@ const pangu = new Pangu();
 
 describe('Symbol { }', () => {
   it('handle { } symbols as curly brackets', () => {
-    expect(pangu.spacingText('前面{中文123漢字}後面')).toBe('前面 {中文 123 漢字} 後面');
-    expect(pangu.spacingText('前面{中文123}後面')).toBe('前面 {中文 123} 後面');
-    expect(pangu.spacingText('前面{123漢字}後面')).toBe('前面 {123 漢字} 後面');
-    expect(pangu.spacingText('前面{中文123} tail')).toBe('前面 {中文 123} tail');
-    expect(pangu.spacingText('head {中文123漢字}後面')).toBe('head {中文 123 漢字} 後面');
-    expect(pangu.spacingText('head {中文123漢字} tail')).toBe('head {中文 123 漢字} tail');
+    expect(pangu.spaceText('前面{中文123漢字}後面')).toBe('前面 {中文 123 漢字} 後面');
+    expect(pangu.spaceText('前面{中文123}後面')).toBe('前面 {中文 123} 後面');
+    expect(pangu.spaceText('前面{123漢字}後面')).toBe('前面 {123 漢字} 後面');
+    expect(pangu.spaceText('前面{中文123} tail')).toBe('前面 {中文 123} tail');
+    expect(pangu.spaceText('head {中文123漢字}後面')).toBe('head {中文 123 漢字} 後面');
+    expect(pangu.spaceText('head {中文123漢字} tail')).toBe('head {中文 123 漢字} tail');
   });
 
   it('handle multiline content in curly brackets', () => {
     // A space before a newline is mid-content, not a bracket-edge space: only the literal string edges get stripped
-    expect(pangu.spacingText('{x \n}中')).toBe('{x \n} 中');
+    expect(pangu.spaceText('{x \n}中')).toBe('{x \n} 中');
   });
 });

--- a/tests/shared/symbol-dashes.test.ts
+++ b/tests/shared/symbol-dashes.test.ts
@@ -6,30 +6,30 @@ const pangu = new Pangu();
 // \u2014
 describe.todo('Symbol —', () => {
   it('handle — symbol', () => {
-    expect(pangu.spacingText('他說——不對')).toBe('他說 —— 不對');
-    expect(pangu.spacingText('台灣——美麗之島')).toBe('台灣 —— 美麗之島');
-    expect(pangu.spacingText('他說———不對')).toBe('他說 ——— 不對');
-    expect(pangu.spacingText('他說 —— 不對')).toBe('他說 —— 不對');
+    expect(pangu.spaceText('他說——不對')).toBe('他說 —— 不對');
+    expect(pangu.spaceText('台灣——美麗之島')).toBe('台灣 —— 美麗之島');
+    expect(pangu.spaceText('他說———不對')).toBe('他說 ——— 不對');
+    expect(pangu.spaceText('他說 —— 不對')).toBe('他說 —— 不對');
   });
 
   // No CJK contact, no change
   it('keep — between ANS untouched', () => {
-    expect(pangu.spacingText('A—B')).toBe('A—B');
-    expect(pangu.spacingText('2020—2024年')).toBe('2020—2024 年');
+    expect(pangu.spaceText('A—B')).toBe('A—B');
+    expect(pangu.spaceText('2020—2024年')).toBe('2020—2024 年');
   });
 });
 
 // \u2500
 describe.todo('Symbol ─', () => {
   it('handle ─ symbol', () => {
-    expect(pangu.spacingText('他說──不對')).toBe('他說 ── 不對');
-    expect(pangu.spacingText('於是──各位觀眾')).toBe('於是 ── 各位觀眾');
-    expect(pangu.spacingText('於是 ── 各位觀眾')).toBe('於是 ── 各位觀眾');
+    expect(pangu.spaceText('他說──不對')).toBe('他說 ── 不對');
+    expect(pangu.spaceText('於是──各位觀眾')).toBe('於是 ── 各位觀眾');
+    expect(pangu.spaceText('於是 ── 各位觀眾')).toBe('於是 ── 各位觀眾');
   });
 
   // No CJK contact, no change
   it('keep ─ between ANS untouched', () => {
-    expect(pangu.spacingText('A─B')).toBe('A─B');
-    expect(pangu.spacingText('2020──2024')).toBe('2020──2024');
+    expect(pangu.spaceText('A─B')).toBe('A─B');
+    expect(pangu.spaceText('2020──2024')).toBe('2020──2024');
   });
 });

--- a/tests/shared/symbol-dollar-sign.test.ts
+++ b/tests/shared/symbol-dollar-sign.test.ts
@@ -5,8 +5,8 @@ const pangu = new Pangu();
 
 describe('Symbol $', () => {
   it('handle $ symbol', () => {
-    expect(pangu.spacingText('前面$後面')).toBe('前面 $ 後面');
-    expect(pangu.spacingText('前面 $ 後面')).toBe('前面 $ 後面');
-    expect(pangu.spacingText('前面$100後面')).toBe('前面 $100 後面');
+    expect(pangu.spaceText('前面$後面')).toBe('前面 $ 後面');
+    expect(pangu.spaceText('前面 $ 後面')).toBe('前面 $ 後面');
+    expect(pangu.spaceText('前面$100後面')).toBe('前面 $100 後面');
   });
 });

--- a/tests/shared/symbol-double-quotes.test.ts
+++ b/tests/shared/symbol-double-quotes.test.ts
@@ -5,49 +5,49 @@ const pangu = new Pangu();
 
 describe('Symbol " "', () => {
   it('handle " " symbols as quotes around CJK', () => {
-    expect(pangu.spacingText('前面"中文123漢字"後面')).toBe('前面 "中文 123 漢字" 後面');
-    expect(pangu.spacingText('前面"中文123"後面')).toBe('前面 "中文 123" 後面');
-    expect(pangu.spacingText('前面"中文abc"後面')).toBe('前面 "中文 abc" 後面');
-    expect(pangu.spacingText('前面"123漢字"後面')).toBe('前面 "123 漢字" 後面');
-    expect(pangu.spacingText('前面"中文123" tail')).toBe('前面 "中文 123" tail');
-    expect(pangu.spacingText('head "中文123漢字"後面')).toBe('head "中文 123 漢字" 後面');
-    expect(pangu.spacingText('head "中文123漢字" tail')).toBe('head "中文 123 漢字" tail');
+    expect(pangu.spaceText('前面"中文123漢字"後面')).toBe('前面 "中文 123 漢字" 後面');
+    expect(pangu.spaceText('前面"中文123"後面')).toBe('前面 "中文 123" 後面');
+    expect(pangu.spaceText('前面"中文abc"後面')).toBe('前面 "中文 abc" 後面');
+    expect(pangu.spaceText('前面"123漢字"後面')).toBe('前面 "123 漢字" 後面');
+    expect(pangu.spaceText('前面"中文123" tail')).toBe('前面 "中文 123" tail');
+    expect(pangu.spaceText('head "中文123漢字"後面')).toBe('head "中文 123 漢字" 後面');
+    expect(pangu.spaceText('head "中文123漢字" tail')).toBe('head "中文 123 漢字" tail');
   });
 
   it('handle separator spacing inside quotes', () => {
-    expect(pangu.spacingText('"字+"')).toBe('"字 +"');
-    expect(pangu.spacingText('"字|"')).toBe('"字 |"');
-    expect(pangu.spacingText('你好"字+"世界')).toBe('你好 "字 +" 世界');
-    expect(pangu.spacingText('前面"字|"後面')).toBe('前面 "字 |" 後面');
-    expect(pangu.spacingText('多行"字+"\n下行"字|"')).toBe('多行 "字 +"\n下行 "字 |"');
+    expect(pangu.spaceText('"字+"')).toBe('"字 +"');
+    expect(pangu.spaceText('"字|"')).toBe('"字 |"');
+    expect(pangu.spaceText('你好"字+"世界')).toBe('你好 "字 +" 世界');
+    expect(pangu.spaceText('前面"字|"後面')).toBe('前面 "字 |" 後面');
+    expect(pangu.spaceText('多行"字+"\n下行"字|"')).toBe('多行 "字 +"\n下行 "字 |"');
   });
 
   it('handle " " symbols as quotes around English', () => {
-    expect(pangu.spacingText('我們也不可以說"We invited the reverend to dinner."')).toBe('我們也不可以說 "We invited the reverend to dinner."');
-    expect(pangu.spacingText('"We invited the Rev. Darling."我們也不可以說')).toBe('"We invited the Rev. Darling." 我們也不可以說');
-    expect(pangu.spacingText('它應該這樣使用："We invited"')).toBe('它應該這樣使用："We invited"');
+    expect(pangu.spaceText('我們也不可以說"We invited the reverend to dinner."')).toBe('我們也不可以說 "We invited the reverend to dinner."');
+    expect(pangu.spaceText('"We invited the Rev. Darling."我們也不可以說')).toBe('"We invited the Rev. Darling." 我們也不可以說');
+    expect(pangu.spaceText('它應該這樣使用："We invited"')).toBe('它應該這樣使用："We invited"');
 
     // prettier-ignore
-    expect(pangu.spacingText('"! git commit -a -m \'蛤\'"'))
+    expect(pangu.spaceText('"! git commit -a -m \'蛤\'"'))
                        .toBe('"! git commit -a -m \'蛤\'"');
 
     // prettier-ignore
-    expect(pangu.spacingText('Rev. (Reverend；牧師的尊稱)這個縮寫嚴格來說並不是一項頭銜，而是形容詞。所以，它應該這樣使用："We invited the Rev. Alan Darling." 或\u00a0 "We\u00a0invited the Rev. Mr. Darling."，而非"We invited the Rev. Darling."我們也不可以說"We invited the reverend to dinner." -- Only a cad would invite the rev. (只有下流的人才會招致批評：句中的 rev. 是 review 的縮寫，算是雙關語)'))
+    expect(pangu.spaceText('Rev. (Reverend；牧師的尊稱)這個縮寫嚴格來說並不是一項頭銜，而是形容詞。所以，它應該這樣使用："We invited the Rev. Alan Darling." 或\u00a0 "We\u00a0invited the Rev. Mr. Darling."，而非"We invited the Rev. Darling."我們也不可以說"We invited the reverend to dinner." -- Only a cad would invite the rev. (只有下流的人才會招致批評：句中的 rev. 是 review 的縮寫，算是雙關語)'))
                        .toBe('Rev. (Reverend；牧師的尊稱) 這個縮寫嚴格來說並不是一項頭銜，而是形容詞。所以，它應該這樣使用："We invited the Rev. Alan Darling." 或\u00a0 "We\u00a0invited the Rev. Mr. Darling."，而非 "We invited the Rev. Darling." 我們也不可以說 "We invited the reverend to dinner." -- Only a cad would invite the rev. (只有下流的人才會招致批評：句中的 rev. 是 review 的縮寫，算是雙關語)');
   });
 
   it('handle " " across the line breaks of a wrapped HTML source', () => {
-    expect(pangu.spacingText('使用："We\ninvited Darling." 或 "We invited."')).toBe('使用："We\ninvited Darling." 或 "We invited."');
+    expect(pangu.spaceText('使用："We\ninvited Darling." 或 "We invited."')).toBe('使用："We\ninvited Darling." 或 "We invited."');
 
     // prettier-ignore
     const text = 'Rev. (Reverend；牧師的尊稱) \n    這個縮寫嚴格來說並不是一項頭銜，而是形容詞。所以，它應該這樣使用："We \n    invited the Rev. Alan Darling." 或\u00a0 "We\u00a0 invited the Rev. Mr. \n    Darling." ，而非 "We invited the Rev. Darling." 我們也不可以說\u00a0 \n    "We invited the reverend to dinner." -- Only a cad would invite the rev. (只有下流的人才會招致批評：句中的 \n    rev. 是 review 的縮寫，算是雙關語) ';
-    expect(pangu.spacingText(text)).toBe(text);
+    expect(pangu.spaceText(text)).toBe(text);
   });
 
   // Rare cases, ignore
   // See https://github.com/vinta/pangu.js/issues/287
   // it('handle " " mis-pairing (known limitation)', () => {
-  //   expect(pangu.spacingText('Darling." 或 "We')).toBe('Darling." 或 "We');
+  //   expect(pangu.spaceText('Darling." 或 "We')).toBe('Darling." 或 "We');
   // });
 });
 
@@ -56,23 +56,23 @@ describe('Symbol " "', () => {
 describe('Symbol “ ”', () => {
   it('handle “ ” symbols as quotes', () => {
     // prettier-ignore
-    expect(pangu.spacingText('阿里云开源“计算王牌”Blink，实时计算时代已来'))
+    expect(pangu.spaceText('阿里云开源“计算王牌”Blink，实时计算时代已来'))
                        .toBe('阿里云开源 “计算王牌” Blink，实时计算时代已来');
 
     // prettier-ignore
-    expect(pangu.spacingText('苹果撤销Facebook“企业证书”后者股价一度短线走低'))
+    expect(pangu.spaceText('苹果撤销Facebook“企业证书”后者股价一度短线走低'))
                        .toBe('苹果撤销 Facebook “企业证书” 后者股价一度短线走低');
 
     // prettier-ignore
-    expect(pangu.spacingText('【UCG中字】“數毛社”DF的《戰神4》全新演示解析'))
+    expect(pangu.spaceText('【UCG中字】“數毛社”DF的《戰神4》全新演示解析'))
                        .toBe('【UCG 中字】“數毛社” DF 的《戰神 4》全新演示解析');
   });
 
   it('handle misused ” ” quote pairs', () => {
-    expect(pangu.spacingText('他说”你好”啊')).toBe('他说 ”你好” 啊');
+    expect(pangu.spaceText('他说”你好”啊')).toBe('他说 ”你好” 啊');
 
     // prettier-ignore
-    expect(pangu.spacingText('《战斧骨》里还有个镜头挺有意思，就是男主”见路不走”，不从峡谷入口走，而选择了从侧面翻越，还顺便借着口哨吸引出来一个食人族给杀了。'))
+    expect(pangu.spaceText('《战斧骨》里还有个镜头挺有意思，就是男主”见路不走”，不从峡谷入口走，而选择了从侧面翻越，还顺便借着口哨吸引出来一个食人族给杀了。'))
                        .toBe('《战斧骨》里还有个镜头挺有意思，就是男主 ”见路不走”，不从峡谷入口走，而选择了从侧面翻越，还顺便借着口哨吸引出来一个食人族给杀了。');
   });
 });

--- a/tests/shared/symbol-ellipsis.test.ts
+++ b/tests/shared/symbol-ellipsis.test.ts
@@ -6,7 +6,7 @@ const pangu = new Pangu();
 describe('Symbol …', () => {
   // \u2026
   it('handle … symbol', () => {
-    expect(pangu.spacingText('前面…後面')).toBe('前面… 後面');
-    expect(pangu.spacingText('前面……後面')).toBe('前面…… 後面');
+    expect(pangu.spaceText('前面…後面')).toBe('前面… 後面');
+    expect(pangu.spaceText('前面……後面')).toBe('前面…… 後面');
   });
 });

--- a/tests/shared/symbol-equals-sign.test.ts
+++ b/tests/shared/symbol-equals-sign.test.ts
@@ -5,26 +5,26 @@ const pangu = new Pangu();
 
 describe('Symbol =', () => {
   it('handle = symbol as operator', () => {
-    expect(pangu.spacingText('前面=後面')).toBe('前面 = 後面');
-    expect(pangu.spacingText('Vinta=陳上進')).toBe('Vinta = 陳上進');
-    expect(pangu.spacingText('陳上進=Vinta')).toBe('陳上進 = Vinta');
+    expect(pangu.spaceText('前面=後面')).toBe('前面 = 後面');
+    expect(pangu.spaceText('Vinta=陳上進')).toBe('Vinta = 陳上進');
+    expect(pangu.spaceText('陳上進=Vinta')).toBe('陳上進 = Vinta');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 = 後面')).toBe('前面 = 後面');
-    expect(pangu.spacingText('Vinta = Mollie')).toBe('Vinta = Mollie');
-    expect(pangu.spacingText('Vinta = 陳上進')).toBe('Vinta = 陳上進');
-    expect(pangu.spacingText('陳上進 = Vinta')).toBe('陳上進 = Vinta');
-    expect(pangu.spacingText('得到一個 A = B 的結果')).toBe('得到一個 A = B 的結果');
+    expect(pangu.spaceText('前面 = 後面')).toBe('前面 = 後面');
+    expect(pangu.spaceText('Vinta = Mollie')).toBe('Vinta = Mollie');
+    expect(pangu.spaceText('Vinta = 陳上進')).toBe('Vinta = 陳上進');
+    expect(pangu.spaceText('陳上進 = Vinta')).toBe('陳上進 = Vinta');
+    expect(pangu.spaceText('得到一個 A = B 的結果')).toBe('得到一個 A = B 的結果');
   });
 
   it('handle = symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta=Mollie')).toBe('Vinta=Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A=B的結果')).toBe('得到一個 A=B 的結果');
-    expect(pangu.spacingText('設定a=1之後執行')).toBe('設定 a=1 之後執行');
-    expect(pangu.spacingText('網址是example.com?foo=bar&baz=1的頁面')).toBe('網址是 example.com?foo=bar&baz=1 的頁面');
+    expect(pangu.spaceText('Vinta=Mollie')).toBe('Vinta=Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A=B的結果')).toBe('得到一個 A=B 的結果');
+    expect(pangu.spaceText('設定a=1之後執行')).toBe('設定 a=1 之後執行');
+    expect(pangu.spaceText('網址是example.com?foo=bar&baz=1的頁面')).toBe('網址是 example.com?foo=bar&baz=1 的頁面');
   });
 
   it('handle = symbol as preserved pattern', () => {
-    expect(pangu.spacingText('用=>寫箭頭函式')).toBe('用 => 寫箭頭函式');
+    expect(pangu.spaceText('用=>寫箭頭函式')).toBe('用 => 寫箭頭函式');
   });
 });

--- a/tests/shared/symbol-exclamation-mark.test.ts
+++ b/tests/shared/symbol-exclamation-mark.test.ts
@@ -5,27 +5,27 @@ const pangu = new Pangu();
 
 describe('Symbol !', () => {
   it('handle ! symbol', () => {
-    expect(pangu.spacingText('前面!')).toBe('前面!');
-    expect(pangu.spacingText('前面!!')).toBe('前面!!');
-    expect(pangu.spacingText('前面!!!')).toBe('前面!!!');
-    expect(pangu.spacingText('前面!後面')).toBe('前面! 後面');
-    expect(pangu.spacingText('前面!!後面')).toBe('前面!! 後面');
-    expect(pangu.spacingText('前面!!!後面')).toBe('前面!!! 後面');
-    expect(pangu.spacingText('前面!abc')).toBe('前面! abc');
-    expect(pangu.spacingText('前面!123')).toBe('前面! 123');
-    expect(pangu.spacingText('前面2!的階乘')).toBe('前面 2! 的階乘');
+    expect(pangu.spaceText('前面!')).toBe('前面!');
+    expect(pangu.spaceText('前面!!')).toBe('前面!!');
+    expect(pangu.spaceText('前面!!!')).toBe('前面!!!');
+    expect(pangu.spaceText('前面!後面')).toBe('前面! 後面');
+    expect(pangu.spaceText('前面!!後面')).toBe('前面!! 後面');
+    expect(pangu.spaceText('前面!!!後面')).toBe('前面!!! 後面');
+    expect(pangu.spaceText('前面!abc')).toBe('前面! abc');
+    expect(pangu.spaceText('前面!123')).toBe('前面! 123');
+    expect(pangu.spaceText('前面2!的階乘')).toBe('前面 2! 的階乘');
 
-    expect(pangu.spacingText('你還在用Yahoo!奇摩？')).toBe('你還在用 Yahoo! 奇摩？');
+    expect(pangu.spaceText('你還在用Yahoo!奇摩？')).toBe('你還在用 Yahoo! 奇摩？');
 
     // prettier-ignore
-    expect(pangu.spacingText('! git commit -a -m "蛤"'))
+    expect(pangu.spaceText('! git commit -a -m "蛤"'))
                        .toBe('! git commit -a -m "蛤"');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 ! 後面')).toBe('前面 ! 後面');
-    expect(pangu.spacingText('前面! 後面')).toBe('前面! 後面');
+    expect(pangu.spaceText('前面 ! 後面')).toBe('前面 ! 後面');
+    expect(pangu.spaceText('前面! 後面')).toBe('前面! 後面');
 
     // Rare cases, ignore
-    // expect(pangu.spacingText('前面 !後面')).toBe('前面 !後面');
+    // expect(pangu.spaceText('前面 !後面')).toBe('前面 !後面');
   });
 });

--- a/tests/shared/symbol-greater-than-sign.test.ts
+++ b/tests/shared/symbol-greater-than-sign.test.ts
@@ -5,25 +5,25 @@ const pangu = new Pangu();
 
 describe('Symbol >', () => {
   it('handle > symbol as operator', () => {
-    expect(pangu.spacingText('前面>後面')).toBe('前面 > 後面');
-    expect(pangu.spacingText('Vinta>陳上進')).toBe('Vinta > 陳上進');
-    expect(pangu.spacingText('陳上進>Vinta')).toBe('陳上進 > Vinta');
-    expect(pangu.spacingText('溫度>30就開冷氣')).toBe('溫度 > 30 就開冷氣');
+    expect(pangu.spaceText('前面>後面')).toBe('前面 > 後面');
+    expect(pangu.spaceText('Vinta>陳上進')).toBe('Vinta > 陳上進');
+    expect(pangu.spaceText('陳上進>Vinta')).toBe('陳上進 > Vinta');
+    expect(pangu.spaceText('溫度>30就開冷氣')).toBe('溫度 > 30 就開冷氣');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 > 後面')).toBe('前面 > 後面');
-    expect(pangu.spacingText('Vinta > Mollie')).toBe('Vinta > Mollie');
-    expect(pangu.spacingText('Vinta > 陳上進')).toBe('Vinta > 陳上進');
-    expect(pangu.spacingText('陳上進 > Vinta')).toBe('陳上進 > Vinta');
-    expect(pangu.spacingText('得到一個 A > B 的結果')).toBe('得到一個 A > B 的結果');
+    expect(pangu.spaceText('前面 > 後面')).toBe('前面 > 後面');
+    expect(pangu.spaceText('Vinta > Mollie')).toBe('Vinta > Mollie');
+    expect(pangu.spaceText('Vinta > 陳上進')).toBe('Vinta > 陳上進');
+    expect(pangu.spaceText('陳上進 > Vinta')).toBe('陳上進 > Vinta');
+    expect(pangu.spaceText('得到一個 A > B 的結果')).toBe('得到一個 A > B 的結果');
   });
 
   it('handle > symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta>Mollie')).toBe('Vinta>Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A>B的結果')).toBe('得到一個 A>B 的結果');
+    expect(pangu.spaceText('Vinta>Mollie')).toBe('Vinta>Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A>B的結果')).toBe('得到一個 A>B 的結果');
   });
 
   it('handle > symbol as preserved pattern', () => {
-    expect(pangu.spacingText('流程是A->B的方向')).toBe('流程是 A->B 的方向');
+    expect(pangu.spaceText('流程是A->B的方向')).toBe('流程是 A->B 的方向');
   });
 });

--- a/tests/shared/symbol-hashtag.test.ts
+++ b/tests/shared/symbol-hashtag.test.ts
@@ -5,15 +5,15 @@ const pangu = new Pangu();
 
 describe('Symbol #', () => {
   it('handle # symbol as hashtag', () => {
-    expect(pangu.spacingText('前面#後面')).toBe('前面 #後面');
-    expect(pangu.spacingText('前面#H2G2後面')).toBe('前面 #H2G2 後面');
-    expect(pangu.spacingText('前面 #銀河便車指南 後面')).toBe('前面 #銀河便車指南 後面');
-    expect(pangu.spacingText('前面#銀河便車指南 後面')).toBe('前面 #銀河便車指南 後面');
-    expect(pangu.spacingText('前面#銀河公車指南 #銀河拖吊車指南 後面')).toBe('前面 #銀河公車指南 #銀河拖吊車指南 後面');
+    expect(pangu.spaceText('前面#後面')).toBe('前面 #後面');
+    expect(pangu.spaceText('前面#H2G2後面')).toBe('前面 #H2G2 後面');
+    expect(pangu.spaceText('前面 #銀河便車指南 後面')).toBe('前面 #銀河便車指南 後面');
+    expect(pangu.spaceText('前面#銀河便車指南 後面')).toBe('前面 #銀河便車指南 後面');
+    expect(pangu.spaceText('前面#銀河公車指南 #銀河拖吊車指南 後面')).toBe('前面 #銀河公車指南 #銀河拖吊車指南 後面');
   });
 
   it('handle # symbol as preserved pattern', () => {
-    expect(pangu.spacingText('前面C#後面')).toBe('前面 C# 後面');
-    expect(pangu.spacingText('前面F#後面')).toBe('前面 F# 後面');
+    expect(pangu.spaceText('前面C#後面')).toBe('前面 C# 後面');
+    expect(pangu.spaceText('前面F#後面')).toBe('前面 F# 後面');
   });
 });

--- a/tests/shared/symbol-less-than-sign.test.ts
+++ b/tests/shared/symbol-less-than-sign.test.ts
@@ -5,22 +5,22 @@ const pangu = new Pangu();
 
 describe('Symbol <', () => {
   it('handle < symbol as operator', () => {
-    expect(pangu.spacingText('前面<後面')).toBe('前面 < 後面');
-    expect(pangu.spacingText('Vinta<陳上進')).toBe('Vinta < 陳上進');
-    expect(pangu.spacingText('陳上進<Vinta')).toBe('陳上進 < Vinta');
+    expect(pangu.spaceText('前面<後面')).toBe('前面 < 後面');
+    expect(pangu.spaceText('Vinta<陳上進')).toBe('Vinta < 陳上進');
+    expect(pangu.spaceText('陳上進<Vinta')).toBe('陳上進 < Vinta');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 < 後面')).toBe('前面 < 後面');
-    expect(pangu.spacingText('Vinta < Mollie')).toBe('Vinta < Mollie');
-    expect(pangu.spacingText('Vinta < 陳上進')).toBe('Vinta < 陳上進');
-    expect(pangu.spacingText('陳上進 < Vinta')).toBe('陳上進 < Vinta');
-    expect(pangu.spacingText('得到一個 A < B 的結果')).toBe('得到一個 A < B 的結果');
+    expect(pangu.spaceText('前面 < 後面')).toBe('前面 < 後面');
+    expect(pangu.spaceText('Vinta < Mollie')).toBe('Vinta < Mollie');
+    expect(pangu.spaceText('Vinta < 陳上進')).toBe('Vinta < 陳上進');
+    expect(pangu.spaceText('陳上進 < Vinta')).toBe('陳上進 < Vinta');
+    expect(pangu.spaceText('得到一個 A < B 的結果')).toBe('得到一個 A < B 的結果');
   });
 
   it('handle < symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta<Mollie')).toBe('Vinta<Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A<B的結果')).toBe('得到一個 A<B 的結果');
-    expect(pangu.spacingText('如果A<B就繼續')).toBe('如果 A<B 就繼續');
-    expect(pangu.spacingText('條件是1<2的情況')).toBe('條件是 1<2 的情況');
+    expect(pangu.spaceText('Vinta<Mollie')).toBe('Vinta<Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A<B的結果')).toBe('得到一個 A<B 的結果');
+    expect(pangu.spaceText('如果A<B就繼續')).toBe('如果 A<B 就繼續');
+    expect(pangu.spaceText('條件是1<2的情況')).toBe('條件是 1<2 的情況');
   });
 });

--- a/tests/shared/symbol-middle-dot.test.ts
+++ b/tests/shared/symbol-middle-dot.test.ts
@@ -6,26 +6,26 @@ const pangu = new Pangu();
 // \u00b7
 describe('Symbol ·', () => {
   it('handle · symbol', () => {
-    expect(pangu.spacingText('前面·後面')).toBe('前面・後面');
-    expect(pangu.spacingText('喬治·R·R·馬丁')).toBe('喬治・R・R・馬丁');
-    expect(pangu.spacingText('M·奈特·沙马兰')).toBe('M・奈特・沙马兰');
+    expect(pangu.spaceText('前面·後面')).toBe('前面・後面');
+    expect(pangu.spaceText('喬治·R·R·馬丁')).toBe('喬治・R・R・馬丁');
+    expect(pangu.spaceText('M·奈特·沙马兰')).toBe('M・奈特・沙马兰');
   });
 });
 
 // \u2022
 describe('Symbol •', () => {
   it('handle • symbol', () => {
-    expect(pangu.spacingText('前面•後面')).toBe('前面・後面');
-    expect(pangu.spacingText('喬治•R•R•馬丁')).toBe('喬治・R・R・馬丁');
-    expect(pangu.spacingText('M•奈特•沙马兰')).toBe('M・奈特・沙马兰');
+    expect(pangu.spaceText('前面•後面')).toBe('前面・後面');
+    expect(pangu.spaceText('喬治•R•R•馬丁')).toBe('喬治・R・R・馬丁');
+    expect(pangu.spaceText('M•奈特•沙马兰')).toBe('M・奈特・沙马兰');
   });
 });
 
 // \u2027
 describe('Symbol ‧', () => {
   it('handle ‧ symbol', () => {
-    expect(pangu.spacingText('前面‧後面')).toBe('前面・後面');
-    expect(pangu.spacingText('喬治‧R‧R‧馬丁')).toBe('喬治・R・R・馬丁');
-    expect(pangu.spacingText('M‧奈特‧沙马兰')).toBe('M・奈特・沙马兰');
+    expect(pangu.spaceText('前面‧後面')).toBe('前面・後面');
+    expect(pangu.spaceText('喬治‧R‧R‧馬丁')).toBe('喬治・R・R・馬丁');
+    expect(pangu.spaceText('M‧奈特‧沙马兰')).toBe('M・奈特・沙马兰');
   });
 });

--- a/tests/shared/symbol-minus-sign.test.ts
+++ b/tests/shared/symbol-minus-sign.test.ts
@@ -5,76 +5,76 @@ const pangu = new Pangu();
 
 describe('Symbol -', () => {
   it('handle - symbol as operator', () => {
-    expect(pangu.spacingText('前面-後面')).toBe('前面 - 後面');
-    expect(pangu.spacingText('Vinta-陳上進')).toBe('Vinta - 陳上進');
-    expect(pangu.spacingText('陳上進-Vinta')).toBe('陳上進 - Vinta');
+    expect(pangu.spaceText('前面-後面')).toBe('前面 - 後面');
+    expect(pangu.spaceText('Vinta-陳上進')).toBe('Vinta - 陳上進');
+    expect(pangu.spaceText('陳上進-Vinta')).toBe('陳上進 - Vinta');
 
     // prettier-ignore
-    expect(pangu.spacingText('博客來-Rewire-神經可塑性：用神經科學突破行為模式迴圈，終結焦慮、恐慌和憂鬱，實現最佳的心理健康')).toBe('博客來 - Rewire - 神經可塑性：用神經科學突破行為模式迴圈，終結焦慮、恐慌和憂鬱，實現最佳的心理健康');
-    expect(pangu.spacingText('博客來-經濟學原理 10/e Mankiw (授權經銷版)')).toBe('博客來 - 經濟學原理 10/e Mankiw (授權經銷版)');
-    expect(pangu.spacingText('財政部電子發票整合服務平台[自然人憑證]-歸戶設定通知')).toBe('財政部電子發票整合服務平台 [自然人憑證] - 歸戶設定通知');
-    expect(pangu.spacingText('博客來-4%法則：讓錢活得比你久的提領金律(電子書)')).toBe('博客來 - 4% 法則：讓錢活得比你久的提領金律 (電子書)');
-    expect(pangu.spacingText('长者的智慧和复杂的维斯特洛- 文章')).toBe('长者的智慧和复杂的维斯特洛 - 文章');
-    expect(pangu.spacingText('1976年-2018年')).toBe('1976 年 - 2018 年');
+    expect(pangu.spaceText('博客來-Rewire-神經可塑性：用神經科學突破行為模式迴圈，終結焦慮、恐慌和憂鬱，實現最佳的心理健康')).toBe('博客來 - Rewire - 神經可塑性：用神經科學突破行為模式迴圈，終結焦慮、恐慌和憂鬱，實現最佳的心理健康');
+    expect(pangu.spaceText('博客來-經濟學原理 10/e Mankiw (授權經銷版)')).toBe('博客來 - 經濟學原理 10/e Mankiw (授權經銷版)');
+    expect(pangu.spaceText('財政部電子發票整合服務平台[自然人憑證]-歸戶設定通知')).toBe('財政部電子發票整合服務平台 [自然人憑證] - 歸戶設定通知');
+    expect(pangu.spaceText('博客來-4%法則：讓錢活得比你久的提領金律(電子書)')).toBe('博客來 - 4% 法則：讓錢活得比你久的提領金律 (電子書)');
+    expect(pangu.spaceText('长者的智慧和复杂的维斯特洛- 文章')).toBe('长者的智慧和复杂的维斯特洛 - 文章');
+    expect(pangu.spaceText('1976年-2018年')).toBe('1976 年 - 2018 年');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 - 後面')).toBe('前面 - 後面');
-    expect(pangu.spacingText('Vinta - Mollie')).toBe('Vinta - Mollie');
-    expect(pangu.spacingText('Vinta - 陳上進')).toBe('Vinta - 陳上進');
-    expect(pangu.spacingText('陳上進 - Vinta')).toBe('陳上進 - Vinta');
-    expect(pangu.spacingText('得到一個 A - B 的結果')).toBe('得到一個 A - B 的結果');
+    expect(pangu.spaceText('前面 - 後面')).toBe('前面 - 後面');
+    expect(pangu.spaceText('Vinta - Mollie')).toBe('Vinta - Mollie');
+    expect(pangu.spaceText('Vinta - 陳上進')).toBe('Vinta - 陳上進');
+    expect(pangu.spaceText('陳上進 - Vinta')).toBe('陳上進 - Vinta');
+    expect(pangu.spaceText('得到一個 A - B 的結果')).toBe('得到一個 A - B 的結果');
   });
 
   it('handle - symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta-Mollie')).toBe('Vinta-Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A-B的結果')).toBe('得到一個 A-B 的結果');
-    expect(pangu.spacingText('去5-A教室上課')).toBe('去 5-A 教室上課');
-    expect(pangu.spacingText('搭2-A的公車')).toBe('搭 2-A 的公車');
-    expect(pangu.spacingText('範圍是1-10的整數')).toBe('範圍是 1-10 的整數');
-    expect(pangu.spacingText('用USB-C充電')).toBe('用 USB-C 充電');
-    expect(pangu.spacingText('照X-RAY檢查')).toBe('照 X-RAY 檢查');
+    expect(pangu.spaceText('Vinta-Mollie')).toBe('Vinta-Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A-B的結果')).toBe('得到一個 A-B 的結果');
+    expect(pangu.spaceText('去5-A教室上課')).toBe('去 5-A 教室上課');
+    expect(pangu.spaceText('搭2-A的公車')).toBe('搭 2-A 的公車');
+    expect(pangu.spaceText('範圍是1-10的整數')).toBe('範圍是 1-10 的整數');
+    expect(pangu.spaceText('用USB-C充電')).toBe('用 USB-C 充電');
+    expect(pangu.spaceText('照X-RAY檢查')).toBe('照 X-RAY 檢查');
 
     // Hyphenated English names
     // prettier-ignore
-    expect(pangu.spacingText('英文姓名須與護照上相同，包含標點符號；範例：王小明，英文名為WANG,HSIAO-MING，請於英文姓(Surname)欄位填入WANG,、英文名(Given Names)欄位填入HSIAO-MING。'))
+    expect(pangu.spaceText('英文姓名須與護照上相同，包含標點符號；範例：王小明，英文名為WANG,HSIAO-MING，請於英文姓(Surname)欄位填入WANG,、英文名(Given Names)欄位填入HSIAO-MING。'))
                        .toBe('英文姓名須與護照上相同，包含標點符號；範例：王小明，英文名為 WANG,HSIAO-MING，請於英文姓 (Surname) 欄位填入 WANG,、英文名 (Given Names) 欄位填入 HSIAO-MING。');
   });
 
   it('handle - symbol as preserved pattern', () => {
     // Compound words
-    expect(pangu.spacingText('Sci-Fi')).toBe('Sci-Fi');
-    expect(pangu.spacingText('X-RAY')).toBe('X-RAY');
-    expect(pangu.spacingText('USB Type-C')).toBe('USB Type-C');
+    expect(pangu.spaceText('Sci-Fi')).toBe('Sci-Fi');
+    expect(pangu.spaceText('X-RAY')).toBe('X-RAY');
+    expect(pangu.spaceText('USB Type-C')).toBe('USB Type-C');
 
     // prettier-ignore
-    expect(pangu.spacingText('The company offered a state-of-the-art machine-learning-powered real-time fraud-detection system with end-to-end encryption and cutting-edge performance.'))
+    expect(pangu.spaceText('The company offered a state-of-the-art machine-learning-powered real-time fraud-detection system with end-to-end encryption and cutting-edge performance.'))
                        .toBe('The company offered a state-of-the-art machine-learning-powered real-time fraud-detection system with end-to-end encryption and cutting-edge performance.');
 
     // prettier-ignore
-    expect(pangu.spacingText('這間公司提供了一套state-of-the-art、machine-learning-powered的real-time fraud-detection系統，具備end-to-end加密功能以及cutting-edge的效能。'))
+    expect(pangu.spaceText('這間公司提供了一套state-of-the-art、machine-learning-powered的real-time fraud-detection系統，具備end-to-end加密功能以及cutting-edge的效能。'))
                        .toBe('這間公司提供了一套 state-of-the-art、machine-learning-powered 的 real-time fraud-detection 系統，具備 end-to-end 加密功能以及 cutting-edge 的效能。');
 
-    expect(pangu.spacingText('Anthropic的claude-4-opus模型')).toBe('Anthropic 的 claude-4-opus 模型');
-    expect(pangu.spacingText('OpenAI的o3-pro模型')).toBe('OpenAI 的 o3-pro 模型');
-    expect(pangu.spacingText('OpenAI的gpt-4o模型')).toBe('OpenAI 的 gpt-4o 模型');
-    expect(pangu.spacingText('OpenAI的GPT-5模型')).toBe('OpenAI 的 GPT-5 模型');
-    expect(pangu.spacingText('Google的gemini-2.5-pro模型')).toBe('Google 的 gemini-2.5-pro 模型');
+    expect(pangu.spaceText('Anthropic的claude-4-opus模型')).toBe('Anthropic 的 claude-4-opus 模型');
+    expect(pangu.spaceText('OpenAI的o3-pro模型')).toBe('OpenAI 的 o3-pro 模型');
+    expect(pangu.spaceText('OpenAI的gpt-4o模型')).toBe('OpenAI 的 gpt-4o 模型');
+    expect(pangu.spaceText('OpenAI的GPT-5模型')).toBe('OpenAI 的 GPT-5 模型');
+    expect(pangu.spaceText('Google的gemini-2.5-pro模型')).toBe('Google 的 gemini-2.5-pro 模型');
   });
 
   it('handle - symbol as affix', () => {
     // CLI flags
     // prettier-ignore
-    expect(pangu.spacingText('你可以使用uname -m指令來檢查你的Linux作業系統是32位元或是[敏感词已被屏蔽]位元'))
+    expect(pangu.spaceText('你可以使用uname -m指令來檢查你的Linux作業系統是32位元或是[敏感词已被屏蔽]位元'))
                        .toBe('你可以使用 uname -m 指令來檢查你的 Linux 作業系統是 32 位元或是 [敏感词已被屏蔽] 位元');
-    expect(pangu.spacingText('參數要加-m的旗標')).toBe('參數要加 -m 的旗標');
+    expect(pangu.spaceText('參數要加-m的旗標')).toBe('參數要加 -m 的旗標');
 
     // Grades
-    expect(pangu.spacingText('得到一個D-的結果')).toBe('得到一個 D- 的結果');
-    expect(pangu.spacingText('得到一個D--的結果')).toBe('得到一個 D-- 的結果');
+    expect(pangu.spaceText('得到一個D-的結果')).toBe('得到一個 D- 的結果');
+    expect(pangu.spaceText('得到一個D--的結果')).toBe('得到一個 D-- 的結果');
 
     // NOTE: fixed by AI spacing, see browser-extensions/chrome/src/ai-spacing/shapes/hyphen-shape.ts
     // The hyphen sign reading was dropped, CJK-N reads as an operator, see ADR 0015
-    // expect(pangu.spacingText('氣溫是-5度左右')).toBe('氣溫是 -5 度左右');
-    // expect(pangu.spacingText('Nasdaq-100本週下跌-13.44%')).toBe('Nasdaq-100 本週下跌 -13.44%');
+    // expect(pangu.spaceText('氣溫是-5度左右')).toBe('氣溫是 -5 度左右');
+    // expect(pangu.spaceText('Nasdaq-100本週下跌-13.44%')).toBe('Nasdaq-100 本週下跌 -13.44%');
   });
 });

--- a/tests/shared/symbol-nbsp.test.ts
+++ b/tests/shared/symbol-nbsp.test.ts
@@ -6,33 +6,33 @@ const pangu = new Pangu();
 describe('Symbol &nbsp;', () => {
   it('handle solitary &nbsp;', () => {
     // The &nbsp; already separates the runs it sits between, so only the genuinely missing 說|We junction gets a space
-    expect(pangu.spacingText('我們說We\u00a0invited')).toBe('我們說 We\u00a0invited');
-    expect(pangu.spacingText('第\u00a05\u00a0章')).toBe('第\u00a05\u00a0章');
+    expect(pangu.spaceText('我們說We\u00a0invited')).toBe('我們說 We\u00a0invited');
+    expect(pangu.spaceText('第\u00a05\u00a0章')).toBe('第\u00a05\u00a0章');
   });
 
   it('handle solitary &nbsp; adjacent to a half-width space', () => {
     // A doubled gap the author wrote. CSS collapses two half-width spaces but never collapses &nbsp; + space, so this paints wider than one space.
     // Dropping either character would be a rewrite, so both stay
-    expect(pangu.spacingText('或\u00a0 "We invited"')).toBe('或\u00a0 "We invited"');
+    expect(pangu.spaceText('或\u00a0 "We invited"')).toBe('或\u00a0 "We invited"');
   });
 
   it('handle consecutive &nbsp;', () => {
     // Runs of 2+ &nbsp;s are deliberate formatting (e.g. paragraph indentation)
-    expect(pangu.spacingText('中文\u00a0\u00a0\u00a0\u00a0中文')).toBe('中文\u00a0\u00a0\u00a0\u00a0中文');
+    expect(pangu.spaceText('中文\u00a0\u00a0\u00a0\u00a0中文')).toBe('中文\u00a0\u00a0\u00a0\u00a0中文');
   });
 
   it('handle &nbsp; adjacent to other whitespace', () => {
-    expect(pangu.spacingText('中文\u00a0\n中文')).toBe('中文\u00a0\n中文');
+    expect(pangu.spaceText('中文\u00a0\n中文')).toBe('中文\u00a0\n中文');
   });
 
   it('handle &nbsp; at string boundaries', () => {
-    expect(pangu.spacingText('\u00a0中文abc')).toBe('\u00a0中文 abc');
-    expect(pangu.spacingText('中文abc\u00a0')).toBe('中文 abc\u00a0');
+    expect(pangu.spaceText('\u00a0中文abc')).toBe('\u00a0中文 abc');
+    expect(pangu.spaceText('中文abc\u00a0')).toBe('中文 abc\u00a0');
   });
 
   it('handle &nbsp; separating a hashtag from CJK', () => {
     // The hashtag guard has to read an &nbsp; as the gap it is, otherwise the # reads as glued to 台北 and gets split off
-    expect(pangu.spacingText('台北\u00a0#中文')).toBe('台北\u00a0#中文');
-    expect(pangu.spacingText('中文#\u00a0abc')).toBe('中文#\u00a0abc');
+    expect(pangu.spaceText('台北\u00a0#中文')).toBe('台北\u00a0#中文');
+    expect(pangu.spaceText('中文#\u00a0abc')).toBe('中文#\u00a0abc');
   });
 });

--- a/tests/shared/symbol-percent-sign.test.ts
+++ b/tests/shared/symbol-percent-sign.test.ts
@@ -5,16 +5,16 @@ const pangu = new Pangu();
 
 describe('Symbol %', () => {
   it('handle % symbol', () => {
-    expect(pangu.spacingText('前面%後面')).toBe('前面 % 後面');
-    expect(pangu.spacingText('前面 % 後面')).toBe('前面 % 後面');
-    expect(pangu.spacingText('前面100%後面')).toBe('前面 100% 後面');
+    expect(pangu.spaceText('前面%後面')).toBe('前面 % 後面');
+    expect(pangu.spaceText('前面 % 後面')).toBe('前面 % 後面');
+    expect(pangu.spaceText('前面100%後面')).toBe('前面 100% 後面');
 
     // prettier-ignore
-    expect(pangu.spacingText('新八的構造成分有95%是眼鏡、3%是水、2%是垃圾'))
+    expect(pangu.spaceText('新八的構造成分有95%是眼鏡、3%是水、2%是垃圾'))
                        .toBe('新八的構造成分有 95% 是眼鏡、3% 是水、2% 是垃圾');
 
     // prettier-ignore
-    expect(pangu.spacingText("丹寧控注意Levi's全館任2件25%OFF滿額再享85折！"))
+    expect(pangu.spaceText("丹寧控注意Levi's全館任2件25%OFF滿額再享85折！"))
                        .toBe("丹寧控注意 Levi's 全館任 2 件 25% OFF 滿額再享 85 折！");
   });
 });

--- a/tests/shared/symbol-period.test.ts
+++ b/tests/shared/symbol-period.test.ts
@@ -5,57 +5,57 @@ const pangu = new Pangu();
 
 describe('Symbol .', () => {
   it('handle . symbol', () => {
-    expect(pangu.spacingText('前面.')).toBe('前面.');
-    expect(pangu.spacingText('前面..')).toBe('前面..');
-    expect(pangu.spacingText('前面...')).toBe('前面...');
-    expect(pangu.spacingText('前面.後面')).toBe('前面. 後面');
-    expect(pangu.spacingText('前面..後面')).toBe('前面.. 後面');
-    expect(pangu.spacingText('前面...後面')).toBe('前面... 後面');
+    expect(pangu.spaceText('前面.')).toBe('前面.');
+    expect(pangu.spaceText('前面..')).toBe('前面..');
+    expect(pangu.spaceText('前面...')).toBe('前面...');
+    expect(pangu.spaceText('前面.後面')).toBe('前面. 後面');
+    expect(pangu.spaceText('前面..後面')).toBe('前面.. 後面');
+    expect(pangu.spaceText('前面...後面')).toBe('前面... 後面');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 . 後面')).toBe('前面 . 後面');
-    expect(pangu.spacingText('前面. 後面')).toBe('前面. 後面');
-    expect(pangu.spacingText('前面 .後面')).toBe('前面 .後面');
+    expect(pangu.spaceText('前面 . 後面')).toBe('前面 . 後面');
+    expect(pangu.spaceText('前面. 後面')).toBe('前面. 後面');
+    expect(pangu.spaceText('前面 .後面')).toBe('前面 .後面');
 
     // Abbreviations
-    expect(pangu.spacingText('前面vs.後面')).toBe('前面 vs. 後面');
-    expect(pangu.spacingText('前面U.S.A.後面')).toBe('前面 U.S.A. 後面');
+    expect(pangu.spaceText('前面vs.後面')).toBe('前面 vs. 後面');
+    expect(pangu.spaceText('前面U.S.A.後面')).toBe('前面 U.S.A. 後面');
 
     // prettier-ignore
-    expect(pangu.spacingText("Mr.龍島主道：「Let's Party!各位高明博雅君子！"))
+    expect(pangu.spaceText("Mr.龍島主道：「Let's Party!各位高明博雅君子！"))
                        .toBe("Mr. 龍島主道：「Let's Party! 各位高明博雅君子！");
 
     // prettier-ignore
-    expect(pangu.spacingText("Mr.龍島主道:「Let's Party!各位高明博雅君子!"))
+    expect(pangu.spaceText("Mr.龍島主道:「Let's Party!各位高明博雅君子!"))
                        .toBe("Mr. 龍島主道:「Let's Party! 各位高明博雅君子!");
 
-    expect(pangu.spacingText('世.界.，草.班.与千.早.爱.音.')).toBe('世. 界.，草. 班. 与千. 早. 爱. 音.');
+    expect(pangu.spaceText('世.界.，草.班.与千.早.爱.音.')).toBe('世. 界.，草. 班. 与千. 早. 爱. 音.');
   });
 
   it('handle . symbol as file extension', () => {
     // File extensions should keep spacing
-    expect(pangu.spacingText('使用Python.py檔案')).toBe('使用 Python.py 檔案');
-    expect(pangu.spacingText('設定檔.env很重要')).toBe('設定檔.env 很重要');
-    expect(pangu.spacingText('編輯器.vscode目錄')).toBe('編輯器.vscode 目錄');
-    expect(pangu.spacingText('黑人問號.jpg後面')).toBe('黑人問號.jpg 後面');
-    expect(pangu.spacingText('黑人問號.jpg 後面')).toBe('黑人問號.jpg 後面');
+    expect(pangu.spaceText('使用Python.py檔案')).toBe('使用 Python.py 檔案');
+    expect(pangu.spaceText('設定檔.env很重要')).toBe('設定檔.env 很重要');
+    expect(pangu.spaceText('編輯器.vscode目錄')).toBe('編輯器.vscode 目錄');
+    expect(pangu.spaceText('黑人問號.jpg後面')).toBe('黑人問號.jpg 後面');
+    expect(pangu.spaceText('黑人問號.jpg 後面')).toBe('黑人問號.jpg 後面');
 
     // Multiple dots
-    expect(pangu.spacingText('檔案package.lock.json存在')).toBe('檔案 package.lock.json 存在');
+    expect(pangu.spaceText('檔案package.lock.json存在')).toBe('檔案 package.lock.json 存在');
 
     // CJK before dot patterns
-    expect(pangu.spacingText('環境.env')).toBe('環境.env');
-    expect(pangu.spacingText('測試.test.js')).toBe('測試.test.js');
-    expect(pangu.spacingText('專案.gitignore')).toBe('專案.gitignore');
+    expect(pangu.spaceText('環境.env')).toBe('環境.env');
+    expect(pangu.spaceText('測試.test.js')).toBe('測試.test.js');
+    expect(pangu.spaceText('專案.gitignore')).toBe('專案.gitignore');
 
     // Mixed patterns
-    expect(pangu.spacingText('使用環境.env配置')).toBe('使用環境.env 配置');
-    expect(pangu.spacingText('專案.prettierrc和.eslintrc')).toBe('專案.prettierrc 和.eslintrc');
+    expect(pangu.spaceText('使用環境.env配置')).toBe('使用環境.env 配置');
+    expect(pangu.spaceText('專案.prettierrc和.eslintrc')).toBe('專案.prettierrc 和.eslintrc');
   });
 
   it('handle . symbol as version number', () => {
-    expect(pangu.spacingText('版本v1.2.3發布了')).toBe('版本 v1.2.3 發布了');
-    expect(pangu.spacingText('pangu.js v1.2.3橫空出世')).toBe('pangu.js v1.2.3 橫空出世');
-    expect(pangu.spacingText('pangu.js 1.2.3橫空出世')).toBe('pangu.js 1.2.3 橫空出世');
+    expect(pangu.spaceText('版本v1.2.3發布了')).toBe('版本 v1.2.3 發布了');
+    expect(pangu.spaceText('pangu.js v1.2.3橫空出世')).toBe('pangu.js v1.2.3 橫空出世');
+    expect(pangu.spaceText('pangu.js 1.2.3橫空出世')).toBe('pangu.js 1.2.3 橫空出世');
   });
 });

--- a/tests/shared/symbol-pipe.test.ts
+++ b/tests/shared/symbol-pipe.test.ts
@@ -5,33 +5,33 @@ const pangu = new Pangu();
 
 describe('Symbol |', () => {
   it('handle | symbol as separator', () => {
-    expect(pangu.spacingText('前面|後面')).toBe('前面 | 後面');
-    expect(pangu.spacingText('Mollie|陳上進')).toBe('Mollie | 陳上進');
-    expect(pangu.spacingText('陳上進|Mollie')).toBe('陳上進 | Mollie');
-    expect(pangu.spacingText('陳上進|貓咪|Mollie')).toBe('陳上進 | 貓咪 | Mollie');
-    expect(pangu.spacingText('陳上進|Mollie|貓咪')).toBe('陳上進 | Mollie | 貓咪');
-    expect(pangu.spacingText('Mollie|Vinta|貓咪')).toBe('Mollie | Vinta | 貓咪');
-    expect(pangu.spacingText('Mollie|陳上進|貓咪')).toBe('Mollie | 陳上進 | 貓咪');
-    expect(pangu.spacingText('作詞|林夕')).toBe('作詞 | 林夕');
-    expect(pangu.spacingText('文|張三 圖|李四')).toBe('文 | 張三 圖 | 李四');
-    expect(pangu.spacingText('支援的 Apple TV 型號|Disney+ 幫助中心|TW')).toBe('支援的 Apple TV 型號 | Disney+ 幫助中心 | TW');
+    expect(pangu.spaceText('前面|後面')).toBe('前面 | 後面');
+    expect(pangu.spaceText('Mollie|陳上進')).toBe('Mollie | 陳上進');
+    expect(pangu.spaceText('陳上進|Mollie')).toBe('陳上進 | Mollie');
+    expect(pangu.spaceText('陳上進|貓咪|Mollie')).toBe('陳上進 | 貓咪 | Mollie');
+    expect(pangu.spaceText('陳上進|Mollie|貓咪')).toBe('陳上進 | Mollie | 貓咪');
+    expect(pangu.spaceText('Mollie|Vinta|貓咪')).toBe('Mollie | Vinta | 貓咪');
+    expect(pangu.spaceText('Mollie|陳上進|貓咪')).toBe('Mollie | 陳上進 | 貓咪');
+    expect(pangu.spaceText('作詞|林夕')).toBe('作詞 | 林夕');
+    expect(pangu.spaceText('文|張三 圖|李四')).toBe('文 | 張三 圖 | 李四');
+    expect(pangu.spaceText('支援的 Apple TV 型號|Disney+ 幫助中心|TW')).toBe('支援的 Apple TV 型號 | Disney+ 幫助中心 | TW');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 | 後面')).toBe('前面 | 後面');
-    expect(pangu.spacingText('Vinta | Mollie')).toBe('Vinta | Mollie');
-    expect(pangu.spacingText('Vinta | Mollie | Kitten')).toBe('Vinta | Mollie | Kitten');
-    expect(pangu.spacingText('陳上進 | 貓咪 | Mollie')).toBe('陳上進 | 貓咪 | Mollie');
-    expect(pangu.spacingText('陳上進 | Mollie | 貓咪')).toBe('陳上進 | Mollie | 貓咪');
-    expect(pangu.spacingText('Mollie | Vinta | 貓咪')).toBe('Mollie | Vinta | 貓咪');
-    expect(pangu.spacingText('Mollie | 陳上進 | 貓咪')).toBe('Mollie | 陳上進 | 貓咪');
+    expect(pangu.spaceText('前面 | 後面')).toBe('前面 | 後面');
+    expect(pangu.spaceText('Vinta | Mollie')).toBe('Vinta | Mollie');
+    expect(pangu.spaceText('Vinta | Mollie | Kitten')).toBe('Vinta | Mollie | Kitten');
+    expect(pangu.spaceText('陳上進 | 貓咪 | Mollie')).toBe('陳上進 | 貓咪 | Mollie');
+    expect(pangu.spaceText('陳上進 | Mollie | 貓咪')).toBe('陳上進 | Mollie | 貓咪');
+    expect(pangu.spaceText('Mollie | Vinta | 貓咪')).toBe('Mollie | Vinta | 貓咪');
+    expect(pangu.spaceText('Mollie | 陳上進 | 貓咪')).toBe('Mollie | 陳上進 | 貓咪');
   });
 
   it('handle | symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta|Mollie')).toBe('Vinta|Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('Vinta|Mollie|Kitten')).toBe('Vinta|Mollie|Kitten');
-    expect(pangu.spacingText('ps aux|grep node')).toBe('ps aux|grep node');
-    expect(pangu.spacingText('條件是x|y的情況')).toBe('條件是 x|y 的情況');
-    expect(pangu.spacingText('得到一個A|B的結果')).toBe('得到一個 A|B 的結果');
-    expect(pangu.spacingText('得到一個A||B的結果')).toBe('得到一個 A||B 的結果');
+    expect(pangu.spaceText('Vinta|Mollie')).toBe('Vinta|Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('Vinta|Mollie|Kitten')).toBe('Vinta|Mollie|Kitten');
+    expect(pangu.spaceText('ps aux|grep node')).toBe('ps aux|grep node');
+    expect(pangu.spaceText('條件是x|y的情況')).toBe('條件是 x|y 的情況');
+    expect(pangu.spaceText('得到一個A|B的結果')).toBe('得到一個 A|B 的結果');
+    expect(pangu.spaceText('得到一個A||B的結果')).toBe('得到一個 A||B 的結果');
   });
 });

--- a/tests/shared/symbol-plus-sign.test.ts
+++ b/tests/shared/symbol-plus-sign.test.ts
@@ -5,122 +5,122 @@ const pangu = new Pangu();
 
 describe('Symbol +', () => {
   it('handle + symbol as operator', () => {
-    expect(pangu.spacingText('前面+後面')).toBe('前面 + 後面');
-    expect(pangu.spacingText('陳上進+Vinta')).toBe('陳上進 + Vinta');
-    expect(pangu.spacingText('Vinta+陳上進')).toBe('Vinta + 陳上進');
-    expect(pangu.spacingText('你+我=我們')).toBe('你 + 我 = 我們');
-    expect(pangu.spacingText('Switch+健身環套組')).toBe('Switch + 健身環套組');
-    expect(pangu.spacingText('MacBook Air M2+滑鼠組合')).toBe('MacBook Air M2 + 滑鼠組合');
+    expect(pangu.spaceText('前面+後面')).toBe('前面 + 後面');
+    expect(pangu.spaceText('陳上進+Vinta')).toBe('陳上進 + Vinta');
+    expect(pangu.spaceText('Vinta+陳上進')).toBe('Vinta + 陳上進');
+    expect(pangu.spaceText('你+我=我們')).toBe('你 + 我 = 我們');
+    expect(pangu.spaceText('Switch+健身環套組')).toBe('Switch + 健身環套組');
+    expect(pangu.spaceText('MacBook Air M2+滑鼠組合')).toBe('MacBook Air M2 + 滑鼠組合');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 + 後面')).toBe('前面 + 後面');
-    expect(pangu.spacingText('Vinta + Mollie')).toBe('Vinta + Mollie');
-    expect(pangu.spacingText('Vinta + 陳上進')).toBe('Vinta + 陳上進');
-    expect(pangu.spacingText('陳上進 + Vinta')).toBe('陳上進 + Vinta');
-    expect(pangu.spacingText('得到一個 A + B 的結果')).toBe('得到一個 A + B 的結果');
+    expect(pangu.spaceText('前面 + 後面')).toBe('前面 + 後面');
+    expect(pangu.spaceText('Vinta + Mollie')).toBe('Vinta + Mollie');
+    expect(pangu.spaceText('Vinta + 陳上進')).toBe('Vinta + 陳上進');
+    expect(pangu.spaceText('陳上進 + Vinta')).toBe('陳上進 + Vinta');
+    expect(pangu.spaceText('得到一個 A + B 的結果')).toBe('得到一個 A + B 的結果');
   });
 
   it('handle + symbol as separator', () => {
     // A plus after a word in CJK contact is undecided by any affix, so plus reading spaces it as a separator, in a bundle plan and on a brand line alike
-    expect(pangu.spacingText('Switch OLED+健身環+保護貼')).toBe('Switch OLED + 健身環 + 保護貼');
+    expect(pangu.spaceText('Switch OLED+健身環+保護貼')).toBe('Switch OLED + 健身環 + 保護貼');
 
     // Plus reading runs before the operator rules, so a CJK+A contact flips the line's later joiners too; a line with no contact keeps them
-    expect(pangu.spacingText('陳上進+Vinta+Mollie')).toBe('陳上進 + Vinta + Mollie');
-    expect(pangu.spacingText('HiNet光世代+MOD+Wi-Fi全屋通')).toBe('HiNet 光世代 + MOD + Wi-Fi 全屋通');
-    expect(pangu.spacingText('套餐含MOD+Netflix+Disney')).toBe('套餐含 MOD+Netflix+Disney');
-    expect(pangu.spacingText('如何使用PTS+（公視+）註冊與觀看？')).toBe('如何使用 PTS+（公視 +）註冊與觀看？');
+    expect(pangu.spaceText('陳上進+Vinta+Mollie')).toBe('陳上進 + Vinta + Mollie');
+    expect(pangu.spaceText('HiNet光世代+MOD+Wi-Fi全屋通')).toBe('HiNet 光世代 + MOD + Wi-Fi 全屋通');
+    expect(pangu.spaceText('套餐含MOD+Netflix+Disney')).toBe('套餐含 MOD+Netflix+Disney');
+    expect(pangu.spaceText('如何使用PTS+（公視+）註冊與觀看？')).toBe('如何使用 PTS+（公視 +）註冊與觀看？');
 
     // NOTE: not expected, cannot fix with rules, but fixed by AI spacing
     // see browser-extensions/chrome/src/ai-spacing/shapes/name-suffix-shape.ts
 
-    expect(pangu.spacingText('MOD+影劇館+上架')).toBe('MOD + 影劇館 + 上架');
-    // expect(pangu.spacingText('MOD+影劇館+上架')).toBe('MOD + 影劇館+ 上架');
+    expect(pangu.spaceText('MOD+影劇館+上架')).toBe('MOD + 影劇館 + 上架');
+    // expect(pangu.spaceText('MOD+影劇館+上架')).toBe('MOD + 影劇館+ 上架');
 
-    expect(pangu.spacingText('Disney+上架了C++課程')).toBe('Disney + 上架了 C++ 課程');
-    // expect(pangu.spacingText('Disney+上架了C++課程')).toBe('Disney+ 上架了 C++ 課程');
+    expect(pangu.spaceText('Disney+上架了C++課程')).toBe('Disney + 上架了 C++ 課程');
+    // expect(pangu.spaceText('Disney+上架了C++課程')).toBe('Disney+ 上架了 C++ 課程');
 
-    expect(pangu.spacingText('Disney+上架了A+B')).toBe('Disney + 上架了 A + B');
-    // expect(pangu.spacingText('Disney+上架了A+B')).toBe('Disney+ 上架了 A + B');
+    expect(pangu.spaceText('Disney+上架了A+B')).toBe('Disney + 上架了 A + B');
+    // expect(pangu.spaceText('Disney+上架了A+B')).toBe('Disney+ 上架了 A + B');
 
-    expect(pangu.spacingText('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV + 等串流平台');
-    // expect(pangu.spacingText('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV+ 等串流平台');
+    expect(pangu.spaceText('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV + 等串流平台');
+    // expect(pangu.spaceText('Netflix、Disney+、Apple TV+等串流平台')).toBe('Netflix、Disney+、Apple TV+ 等串流平台');
 
     // prettier-ignore
-    expect(pangu.spacingText('HiNet光世代+MOD+影劇館+/全選/自選20/特選餐/豪華餐(5選1)+Wi-Fi全屋通(1台)'))
+    expect(pangu.spaceText('HiNet光世代+MOD+影劇館+/全選/自選20/特選餐/豪華餐(5選1)+Wi-Fi全屋通(1台)'))
                        .toBe('HiNet 光世代 + MOD + 影劇館 + /全選/自選 20/特選餐/豪華餐 (5 選 1) + Wi-Fi 全屋通 (1 台)');
-    // expect(pangu.spacingText('HiNet光世代+MOD+影劇館+/全選/自選20/特選餐/豪華餐(5選1)+Wi-Fi全屋通(1台)'))
+    // expect(pangu.spaceText('HiNet光世代+MOD+影劇館+/全選/自選20/特選餐/豪華餐(5選1)+Wi-Fi全屋通(1台)'))
     //                    .toBe('HiNet 光世代 + MOD + 影劇館+/全選/自選 20/特選餐/豪華餐 (5 選 1) + Wi-Fi 全屋通 (1 台)');
 
     // prettier-ignore
-    expect(pangu.spacingText('【速在必行方案】HiNet光世代+Wi-Fi全屋通1台+MOD影劇館+(300M/300M)'))
+    expect(pangu.spaceText('【速在必行方案】HiNet光世代+Wi-Fi全屋通1台+MOD影劇館+(300M/300M)'))
                           .toBe('【速在必行方案】HiNet 光世代 + Wi-Fi 全屋通 1 台 + MOD 影劇館 + (300M/300M)');
-    // expect(pangu.spacingText('【速在必行方案】HiNet光世代+Wi-Fi全屋通1台+MOD影劇館+(300M/300M)'))
+    // expect(pangu.spaceText('【速在必行方案】HiNet光世代+Wi-Fi全屋通1台+MOD影劇館+(300M/300M)'))
     //                    .toBe('【速在必行方案】HiNet 光世代 + Wi-Fi 全屋通 1 台 + MOD 影劇館+ (300M/300M)');
 
     // On a line with two or more pluses, a plus after a closing bracket is a separator even before an opening full-width quote, which takes no space on its side; one plus stays tight
     // prettier-ignore
-    expect(pangu.spacingText('HiNet光世代+MOD+自選餐(全選)+「影劇館+」'))
+    expect(pangu.spaceText('HiNet光世代+MOD+自選餐(全選)+「影劇館+」'))
                        .toBe('HiNet 光世代 + MOD + 自選餐 (全選) +「影劇館 +」');
-    // expect(pangu.spacingText('HiNet光世代+MOD+自選餐(全選)+「影劇館+」'))
+    // expect(pangu.spaceText('HiNet光世代+MOD+自選餐(全選)+「影劇館+」'))
     //                    .toBe('HiNet 光世代 + MOD + 自選餐 (全選) +「影劇館+」');
   });
 
   // FIXME
   it.todo('handle + symbol as separator after a closing bracket on a single-plus line', () => {
-    expect(pangu.spacingText('自選餐(全選)+「影劇館」')).toBe('自選餐 (全選) +「影劇館」');
+    expect(pangu.spaceText('自選餐(全選)+「影劇館」')).toBe('自選餐 (全選) +「影劇館」');
   });
 
   // FIXME
   it.todo('handle + symbol as separator after a product name ending in a digit', () => {
-    expect(pangu.spacingText('Switch 2+瑪利歐賽車世界同捆組')).toBe('Switch 2 + 瑪利歐賽車世界同捆組');
+    expect(pangu.spaceText('Switch 2+瑪利歐賽車世界同捆組')).toBe('Switch 2 + 瑪利歐賽車世界同捆組');
   });
 
   it('handle + symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta+Mollie')).toBe('Vinta+Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('前面A+B後面')).toBe('前面 A+B 後面');
-    expect(pangu.spacingText('得到一個A+B的結果')).toBe('得到一個 A+B 的結果');
-    expect(pangu.spacingText('答案是5+5的和')).toBe('答案是 5+5 的和');
+    expect(pangu.spaceText('Vinta+Mollie')).toBe('Vinta+Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('前面A+B後面')).toBe('前面 A+B 後面');
+    expect(pangu.spaceText('得到一個A+B的結果')).toBe('得到一個 A+B 的結果');
+    expect(pangu.spaceText('答案是5+5的和')).toBe('答案是 5+5 的和');
   });
 
   it('handle + symbol as preserved pattern', () => {
-    expect(pangu.spacingText('得到一個C++的結果')).toBe('得到一個 C++ 的結果');
-    expect(pangu.spacingText('得到一個 C++的結果')).toBe('得到一個 C++ 的結果');
-    expect(pangu.spacingText('得到一個i++的結果')).toBe('得到一個 i++ 的結果');
-    expect(pangu.spacingText('我會寫C++的程式')).toBe('我會寫 C++ 的程式');
+    expect(pangu.spaceText('得到一個C++的結果')).toBe('得到一個 C++ 的結果');
+    expect(pangu.spaceText('得到一個 C++的結果')).toBe('得到一個 C++ 的結果');
+    expect(pangu.spaceText('得到一個i++的結果')).toBe('得到一個 i++ 的結果');
+    expect(pangu.spaceText('我會寫C++的程式')).toBe('我會寫 C++ 的程式');
   });
 
   it('handle + symbol as affix', () => {
     // Grades
-    expect(pangu.spacingText('得到一個A+的結果')).toBe('得到一個 A+ 的結果');
-    expect(pangu.spacingText('得到一個 A+ 的結果')).toBe('得到一個 A+ 的結果');
-    expect(pangu.spacingText('成績是A+的等級')).toBe('成績是 A+ 的等級');
+    expect(pangu.spaceText('得到一個A+的結果')).toBe('得到一個 A+ 的結果');
+    expect(pangu.spaceText('得到一個 A+ 的結果')).toBe('得到一個 A+ 的結果');
+    expect(pangu.spaceText('成績是A+的等級')).toBe('成績是 A+ 的等級');
 
     // Sign before digits
-    expect(pangu.spacingText('打+886這個號碼')).toBe('打 +886 這個號碼');
-    expect(pangu.spacingText('氣溫是+5度左右')).toBe('氣溫是 +5 度左右');
+    expect(pangu.spaceText('打+886這個號碼')).toBe('打 +886 這個號碼');
+    expect(pangu.spaceText('氣溫是+5度左右')).toBe('氣溫是 +5 度左右');
 
     // Suffix after a digit run
-    expect(pangu.spacingText('有100+的選擇')).toBe('有 100+ 的選擇');
-    expect(pangu.spacingText('這裡有18+的內容')).toBe('這裡有 18+ 的內容');
-    expect(pangu.spacingText('評分3.5+的餐廳')).toBe('評分 3.5+ 的餐廳');
-    expect(pangu.spacingText('Python 3+的版本')).toBe('Python 3+ 的版本');
+    expect(pangu.spaceText('有100+的選擇')).toBe('有 100+ 的選擇');
+    expect(pangu.spaceText('這裡有18+的內容')).toBe('這裡有 18+ 的內容');
+    expect(pangu.spaceText('評分3.5+的餐廳')).toBe('評分 3.5+ 的餐廳');
+    expect(pangu.spaceText('Python 3+的版本')).toBe('Python 3+ 的版本');
 
     // NOTE: not expected, cannot fix with rules, but fixed by AI spacing
     // see browser-extensions/chrome/src/ai-spacing/shapes/name-suffix-shape.ts
 
-    expect(pangu.spacingText('Disney+上架了新片')).toBe('Disney + 上架了新片');
-    // expect(pangu.spacingText('Disney+上架了新片')).toBe('Disney+ 上架了新片');
+    expect(pangu.spaceText('Disney+上架了新片')).toBe('Disney + 上架了新片');
+    // expect(pangu.spaceText('Disney+上架了新片')).toBe('Disney+ 上架了新片');
 
-    expect(pangu.spacingText('Apple TV+上架了新片')).toBe('Apple TV + 上架了新片');
-    // expect(pangu.spacingText('Apple TV+上架了新片')).toBe('Apple TV+ 上架了新片');
+    expect(pangu.spaceText('Apple TV+上架了新片')).toBe('Apple TV + 上架了新片');
+    // expect(pangu.spaceText('Apple TV+上架了新片')).toBe('Apple TV+ 上架了新片');
 
-    expect(pangu.spacingText('Disney+和Apple TV+都上架了')).toBe('Disney + 和 Apple TV + 都上架了');
-    // expect(pangu.spacingText('Disney+和Apple TV+都上架了')).toBe('Disney+ 和 Apple TV+ 都上架了');
+    expect(pangu.spaceText('Disney+和Apple TV+都上架了')).toBe('Disney + 和 Apple TV + 都上架了');
+    // expect(pangu.spaceText('Disney+和Apple TV+都上架了')).toBe('Disney+ 和 Apple TV+ 都上架了');
 
-    expect(pangu.spacingText('公視+上架了新片')).toBe('公視 + 上架了新片');
-    // expect(pangu.spacingText('公視+上架了新片')).toBe('公視+ 上架了新片');
+    expect(pangu.spaceText('公視+上架了新片')).toBe('公視 + 上架了新片');
+    // expect(pangu.spaceText('公視+上架了新片')).toBe('公視+ 上架了新片');
 
-    expect(pangu.spacingText('MOD影劇館+上架了新片')).toBe('MOD 影劇館 + 上架了新片');
-    // expect(pangu.spacingText('MOD影劇館+上架了新片')).toBe('MOD 影劇館+ 上架了新片');
+    expect(pangu.spaceText('MOD影劇館+上架了新片')).toBe('MOD 影劇館 + 上架了新片');
+    // expect(pangu.spaceText('MOD影劇館+上架了新片')).toBe('MOD 影劇館+ 上架了新片');
   });
 });

--- a/tests/shared/symbol-question-mark.test.ts
+++ b/tests/shared/symbol-question-mark.test.ts
@@ -5,21 +5,21 @@ const pangu = new Pangu();
 
 describe('Symbol ?', () => {
   it('handle ? symbol', () => {
-    expect(pangu.spacingText('前面?')).toBe('前面?');
-    expect(pangu.spacingText('前面??')).toBe('前面??');
-    expect(pangu.spacingText('前面???')).toBe('前面???');
-    expect(pangu.spacingText('前面?後面')).toBe('前面? 後面');
-    expect(pangu.spacingText('前面??後面')).toBe('前面?? 後面');
-    expect(pangu.spacingText('前面???後面')).toBe('前面??? 後面');
-    expect(pangu.spacingText('前面?abc')).toBe('前面? abc');
-    expect(pangu.spacingText('前面?123')).toBe('前面? 123');
-    expect(pangu.spacingText('所以,請問Jackey的鼻子有幾個?3.14個')).toBe('所以, 請問 Jackey 的鼻子有幾個? 3.14 個');
+    expect(pangu.spaceText('前面?')).toBe('前面?');
+    expect(pangu.spaceText('前面??')).toBe('前面??');
+    expect(pangu.spaceText('前面???')).toBe('前面???');
+    expect(pangu.spaceText('前面?後面')).toBe('前面? 後面');
+    expect(pangu.spaceText('前面??後面')).toBe('前面?? 後面');
+    expect(pangu.spaceText('前面???後面')).toBe('前面??? 後面');
+    expect(pangu.spaceText('前面?abc')).toBe('前面? abc');
+    expect(pangu.spaceText('前面?123')).toBe('前面? 123');
+    expect(pangu.spaceText('所以,請問Jackey的鼻子有幾個?3.14個')).toBe('所以, 請問 Jackey 的鼻子有幾個? 3.14 個');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 ? 後面')).toBe('前面 ? 後面');
-    expect(pangu.spacingText('前面? 後面')).toBe('前面? 後面');
+    expect(pangu.spaceText('前面 ? 後面')).toBe('前面 ? 後面');
+    expect(pangu.spaceText('前面? 後面')).toBe('前面? 後面');
 
     // Rare cases, ignore
-    // expect(pangu.spacingText('前面 ?後面')).toBe('前面 ?後面');
+    // expect(pangu.spaceText('前面 ?後面')).toBe('前面 ?後面');
   });
 });

--- a/tests/shared/symbol-round-brackets.test.ts
+++ b/tests/shared/symbol-round-brackets.test.ts
@@ -5,32 +5,32 @@ const pangu = new Pangu();
 
 describe('Symbol ( )', () => {
   it('handle ( ) symbols as round brackets', () => {
-    expect(pangu.spacingText('前面(中文123漢字)後面')).toBe('前面 (中文 123 漢字) 後面');
-    expect(pangu.spacingText('前面(中文123)後面')).toBe('前面 (中文 123) 後面');
-    expect(pangu.spacingText('前面(123漢字)後面')).toBe('前面 (123 漢字) 後面');
-    expect(pangu.spacingText('前面(中文123) tail')).toBe('前面 (中文 123) tail');
-    expect(pangu.spacingText('head (中文123漢字)後面')).toBe('head (中文 123 漢字) 後面');
-    expect(pangu.spacingText('head (中文123漢字) tail')).toBe('head (中文 123 漢字) tail');
-    expect(pangu.spacingText('(or simply "React")')).toBe('(or simply "React")');
-    expect(pangu.spacingText('function(123)')).toBe('function(123)');
-    expect(pangu.spacingText('我看过的电影(1404)')).toBe('我看过的电影 (1404)');
+    expect(pangu.spaceText('前面(中文123漢字)後面')).toBe('前面 (中文 123 漢字) 後面');
+    expect(pangu.spaceText('前面(中文123)後面')).toBe('前面 (中文 123) 後面');
+    expect(pangu.spaceText('前面(123漢字)後面')).toBe('前面 (123 漢字) 後面');
+    expect(pangu.spaceText('前面(中文123) tail')).toBe('前面 (中文 123) tail');
+    expect(pangu.spaceText('head (中文123漢字)後面')).toBe('head (中文 123 漢字) 後面');
+    expect(pangu.spaceText('head (中文123漢字) tail')).toBe('head (中文 123 漢字) tail');
+    expect(pangu.spaceText('(or simply "React")')).toBe('(or simply "React")');
+    expect(pangu.spaceText('function(123)')).toBe('function(123)');
+    expect(pangu.spaceText('我看过的电影(1404)')).toBe('我看过的电影 (1404)');
 
     // prettier-ignore
-    expect(pangu.spacingText('預定於繳款截止日114/07/02(遇假日順延)之次一營業日進行扣款'))
+    expect(pangu.spaceText('預定於繳款截止日114/07/02(遇假日順延)之次一營業日進行扣款'))
                        .toBe('預定於繳款截止日 114/07/02 (遇假日順延) 之次一營業日進行扣款');
 
     // prettier-ignore
-    expect(pangu.spacingText("OperationalError: (2006, 'MySQL server has gone away')"))
+    expect(pangu.spaceText("OperationalError: (2006, 'MySQL server has gone away')"))
                        .toBe("OperationalError: (2006, 'MySQL server has gone away')");
 
     // prettier-ignore
-    expect(pangu.spacingText('Chang Stream(变更记录流)是指collection(数据库集合)的变更事件流'))
+    expect(pangu.spaceText('Chang Stream(变更记录流)是指collection(数据库集合)的变更事件流'))
                        .toBe('Chang Stream (变更记录流) 是指 collection (数据库集合) 的变更事件流');
   });
 
   it('handle multiline content in round brackets', () => {
     // A space before a newline is mid-content, not a bracket-edge space: only the literal string edges get stripped
-    expect(pangu.spacingText('(x \n)中')).toBe('(x \n) 中');
-    expect(pangu.spacingText('(參數 \n)後面')).toBe('(參數 \n) 後面');
+    expect(pangu.spaceText('(x \n)中')).toBe('(x \n) 中');
+    expect(pangu.spaceText('(參數 \n)後面')).toBe('(參數 \n) 後面');
   });
 });

--- a/tests/shared/symbol-semicolon.test.ts
+++ b/tests/shared/symbol-semicolon.test.ts
@@ -5,13 +5,13 @@ const pangu = new Pangu();
 
 describe('Symbol ;', () => {
   it('handle ; symbol', () => {
-    expect(pangu.spacingText('前面;後面')).toBe('前面; 後面');
+    expect(pangu.spaceText('前面;後面')).toBe('前面; 後面');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 ; 後面')).toBe('前面 ; 後面');
-    expect(pangu.spacingText('前面; 後面')).toBe('前面; 後面');
+    expect(pangu.spaceText('前面 ; 後面')).toBe('前面 ; 後面');
+    expect(pangu.spaceText('前面; 後面')).toBe('前面; 後面');
 
     // Rare cases, ignore
-    // expect(pangu.spacingText('前面 ;後面')).toBe('前面 ;後面');
+    // expect(pangu.spaceText('前面 ;後面')).toBe('前面 ;後面');
   });
 });

--- a/tests/shared/symbol-single-quotes.test.ts
+++ b/tests/shared/symbol-single-quotes.test.ts
@@ -6,26 +6,26 @@ const pangu = new Pangu();
 describe("Symbol ' '", () => {
   it("handle ' ' symbols as quotes", () => {
     // prettier-ignore
-    expect(pangu.spacingText("Why are Python's 'private' methods not actually private?"))
+    expect(pangu.spaceText("Why are Python's 'private' methods not actually private?"))
                        .toBe("Why are Python's 'private' methods not actually private?");
 
     // prettier-ignore
-    expect(pangu.spacingText("举个栗子，如果一道题只包含'A' ~ 'Z'意味着字符集大小是"))
+    expect(pangu.spaceText("举个栗子，如果一道题只包含'A' ~ 'Z'意味着字符集大小是"))
                        .toBe("举个栗子，如果一道题只包含 'A' ~ 'Z' 意味着字符集大小是");
 
     // prettier-ignore
-    expect(pangu.spacingText("后续会直接用iframe window.addEventListener('message')"))
+    expect(pangu.spaceText("后续会直接用iframe window.addEventListener('message')"))
                        .toBe("后续会直接用 iframe window.addEventListener('message')");
 
     // prettier-ignore
-    expect(pangu.spacingText(`'! git commit -a -m "蛤"'`))
+    expect(pangu.spaceText(`'! git commit -a -m "蛤"'`))
                        .toBe(`'! git commit -a -m "蛤"'`);
 
     // Single quotes around Chinese text should not have spaces added
-    expect(pangu.spacingText("Remove '铁蕾' from 1 Folder?")).toBe("Remove '铁蕾' from 1 Folder?");
+    expect(pangu.spaceText("Remove '铁蕾' from 1 Folder?")).toBe("Remove '铁蕾' from 1 Folder?");
   });
 
   it("handle ' symbols as apostrophe", () => {
-    expect(pangu.spacingText("陳上進 likes 林依諾's status.")).toBe("陳上進 likes 林依諾's status.");
+    expect(pangu.spaceText("陳上進 likes 林依諾's status.")).toBe("陳上進 likes 林依諾's status.");
   });
 });

--- a/tests/shared/symbol-slash.test.ts
+++ b/tests/shared/symbol-slash.test.ts
@@ -5,159 +5,159 @@ const pangu = new Pangu();
 
 describe('Symbol /', () => {
   it('handle / symbol as operator', () => {
-    expect(pangu.spacingText('前面/後面')).toBe('前面 / 後面');
-    expect(pangu.spacingText('Mollie/陳上進')).toBe('Mollie / 陳上進');
-    expect(pangu.spacingText('陳上進/Mollie')).toBe('陳上進 / Mollie');
-    expect(pangu.spacingText('速度是60公里/小時')).toBe('速度是 60 公里 / 小時');
+    expect(pangu.spaceText('前面/後面')).toBe('前面 / 後面');
+    expect(pangu.spaceText('Mollie/陳上進')).toBe('Mollie / 陳上進');
+    expect(pangu.spaceText('陳上進/Mollie')).toBe('陳上進 / Mollie');
+    expect(pangu.spaceText('速度是60公里/小時')).toBe('速度是 60 公里 / 小時');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 / 後面')).toBe('前面 / 後面');
-    expect(pangu.spacingText('Vinta / Mollie')).toBe('Vinta / Mollie');
-    expect(pangu.spacingText('Mollie / 陳上進')).toBe('Mollie / 陳上進');
-    expect(pangu.spacingText('陳上進 / Mollie')).toBe('陳上進 / Mollie');
-    expect(pangu.spacingText('得到一個 A / B 的結果')).toBe('得到一個 A / B 的結果');
-    expect(pangu.spacingText('好人 / bad guy')).toBe('好人 / bad guy');
-    expect(pangu.spacingText('吃apple / banana')).toBe('吃 apple / banana');
+    expect(pangu.spaceText('前面 / 後面')).toBe('前面 / 後面');
+    expect(pangu.spaceText('Vinta / Mollie')).toBe('Vinta / Mollie');
+    expect(pangu.spaceText('Mollie / 陳上進')).toBe('Mollie / 陳上進');
+    expect(pangu.spaceText('陳上進 / Mollie')).toBe('陳上進 / Mollie');
+    expect(pangu.spaceText('得到一個 A / B 的結果')).toBe('得到一個 A / B 的結果');
+    expect(pangu.spaceText('好人 / bad guy')).toBe('好人 / bad guy');
+    expect(pangu.spaceText('吃apple / banana')).toBe('吃 apple / banana');
   });
 
   it('handle / symbol as joiner token', () => {
-    expect(pangu.spacingText('Vinta/Mollie')).toBe('Vinta/Mollie'); // If no CJK, DO NOT change
-    expect(pangu.spacingText('得到一個A/B的結果')).toBe('得到一個 A/B 的結果');
-    expect(pangu.spacingText('他要做A/B測試')).toBe('他要做 A/B 測試');
-    expect(pangu.spacingText('打東東26/30')).toBe('打東東 26/30');
-    expect(pangu.spacingText('打東東1/denominator')).toBe('打東東 1/denominator');
-    expect(pangu.spacingText('吃apple/banana')).toBe('吃 apple/banana');
-    expect(pangu.spacingText('選A/B其中一個')).toBe('選 A/B 其中一個');
-    expect(pangu.spacingText('答案是6/2的商數')).toBe('答案是 6/2 的商數');
-    expect(pangu.spacingText('安装指令：npx skills add vinta/hal-9000')).toBe('安装指令：npx skills add vinta/hal-9000');
+    expect(pangu.spaceText('Vinta/Mollie')).toBe('Vinta/Mollie'); // If no CJK, DO NOT change
+    expect(pangu.spaceText('得到一個A/B的結果')).toBe('得到一個 A/B 的結果');
+    expect(pangu.spaceText('他要做A/B測試')).toBe('他要做 A/B 測試');
+    expect(pangu.spaceText('打東東26/30')).toBe('打東東 26/30');
+    expect(pangu.spaceText('打東東1/denominator')).toBe('打東東 1/denominator');
+    expect(pangu.spaceText('吃apple/banana')).toBe('吃 apple/banana');
+    expect(pangu.spaceText('選A/B其中一個')).toBe('選 A/B 其中一個');
+    expect(pangu.spaceText('答案是6/2的商數')).toBe('答案是 6/2 的商數');
+    expect(pangu.spaceText('安装指令：npx skills add vinta/hal-9000')).toBe('安装指令：npx skills add vinta/hal-9000');
   });
 
   it('handle / symbol per line', () => {
-    expect(pangu.spacingText('我/你\n他/她')).toBe('我 / 你\n他 / 她');
-    expect(pangu.spacingText('歡迎光臨/再見\n參考 https://example.com/docs')).toBe('歡迎光臨 / 再見\n參考 https://example.com/docs');
+    expect(pangu.spaceText('我/你\n他/她')).toBe('我 / 你\n他 / 她');
+    expect(pangu.spaceText('歡迎光臨/再見\n參考 https://example.com/docs')).toBe('歡迎光臨 / 再見\n參考 https://example.com/docs');
   });
 
   it('handle / symbol as list', () => {
-    expect(pangu.spacingText('陳上進/貓咪/Mollie')).toBe('陳上進/貓咪/Mollie');
-    expect(pangu.spacingText('陳上進/Mollie/貓咪')).toBe('陳上進/Mollie/貓咪');
-    expect(pangu.spacingText('Mollie/Vinta/貓咪')).toBe('Mollie/Vinta/貓咪');
-    expect(pangu.spacingText('Mollie/陳上進/貓咪')).toBe('Mollie/陳上進/貓咪');
-    expect(pangu.spacingText('日期是2024/01/22的早上')).toBe('日期是 2024/01/22 的早上');
+    expect(pangu.spaceText('陳上進/貓咪/Mollie')).toBe('陳上進/貓咪/Mollie');
+    expect(pangu.spaceText('陳上進/Mollie/貓咪')).toBe('陳上進/Mollie/貓咪');
+    expect(pangu.spaceText('Mollie/Vinta/貓咪')).toBe('Mollie/Vinta/貓咪');
+    expect(pangu.spaceText('Mollie/陳上進/貓咪')).toBe('Mollie/陳上進/貓咪');
+    expect(pangu.spaceText('日期是2024/01/22的早上')).toBe('日期是 2024/01/22 的早上');
 
     // prettier-ignore
-    expect(pangu.spacingText("8964/3★集會所接待員/克隆·麻煩大師/手卷師傅（已退休）/主程式毀滅者/dae-dae-o/#絕地家庭小會議/#今天大掃除了沒有/NS編號在banner裡/discord:史單力#3230"))
+    expect(pangu.spaceText("8964/3★集會所接待員/克隆·麻煩大師/手卷師傅（已退休）/主程式毀滅者/dae-dae-o/#絕地家庭小會議/#今天大掃除了沒有/NS編號在banner裡/discord:史單力#3230"))
                        .toBe("8964/3★集會所接待員/克隆・麻煩大師/手卷師傅（已退休）/主程式毀滅者/dae-dae-o/#絕地家庭小會議/#今天大掃除了沒有/NS 編號在 banner 裡/discord: 史單力 #3230");
 
     // prettier-ignore
-    expect(pangu.spacingText("after 80'/气象工作者/不苟同/关注abc天气变化/向往123自由/热爱科学、互联网、编程Node.js Web C++ Julia Python"))
+    expect(pangu.spaceText("after 80'/气象工作者/不苟同/关注abc天气变化/向往123自由/热爱科学、互联网、编程Node.js Web C++ Julia Python"))
                        .toBe("after 80'/气象工作者/不苟同/关注 abc 天气变化/向往 123 自由/热爱科学、互联网、编程 Node.js Web C++ Julia Python");
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('陳上進 / 貓咪 / Mollie')).toBe('陳上進 / 貓咪 / Mollie');
-    expect(pangu.spacingText('陳上進 / Mollie / 貓咪')).toBe('陳上進 / Mollie / 貓咪');
-    expect(pangu.spacingText('Mollie / Vinta / 貓咪')).toBe('Mollie / Vinta / 貓咪');
-    expect(pangu.spacingText('Mollie / 陳上進 / 貓咪')).toBe('Mollie / 陳上進 / 貓咪');
+    expect(pangu.spaceText('陳上進 / 貓咪 / Mollie')).toBe('陳上進 / 貓咪 / Mollie');
+    expect(pangu.spaceText('陳上進 / Mollie / 貓咪')).toBe('陳上進 / Mollie / 貓咪');
+    expect(pangu.spaceText('Mollie / Vinta / 貓咪')).toBe('Mollie / Vinta / 貓咪');
+    expect(pangu.spaceText('Mollie / 陳上進 / 貓咪')).toBe('Mollie / 陳上進 / 貓咪');
 
     // prettier-ignore
-    expect(pangu.spacingText('2016-12-26(奇幻电影节) / 2017-01-20(美国) / 詹姆斯麦卡沃伊'))
+    expect(pangu.spaceText('2016-12-26(奇幻电影节) / 2017-01-20(美国) / 詹姆斯麦卡沃伊'))
                        .toBe('2016-12-26 (奇幻电影节) / 2017-01-20 (美国) / 詹姆斯麦卡沃伊');
   });
 
   it('handle / symbol as Unix absolute file path', () => {
     // prettier-ignore
-    expect(pangu.spacingText('/home和/root是Linux中的頂級目錄'))
+    expect(pangu.spaceText('/home和/root是Linux中的頂級目錄'))
                        .toBe('/home 和 /root 是 Linux 中的頂級目錄');
 
     // prettier-ignore
-    expect(pangu.spacingText('/home/與/root是Linux中的頂級目錄'))
+    expect(pangu.spaceText('/home/與/root是Linux中的頂級目錄'))
                        .toBe('/home/ 與 /root 是 Linux 中的頂級目錄');
 
     // prettier-ignore
-    expect(pangu.spacingText('"/home/"和"/root"是Linux中的頂級目錄'))
+    expect(pangu.spaceText('"/home/"和"/root"是Linux中的頂級目錄'))
                        .toBe('"/home/" 和 "/root" 是 Linux 中的頂級目錄');
 
     // prettier-ignore
-    expect(pangu.spacingText('當你用cat和od指令查看/dev/random和/dev/urandom的內容時'))
+    expect(pangu.spaceText('當你用cat和od指令查看/dev/random和/dev/urandom的內容時'))
                        .toBe('當你用 cat 和 od 指令查看 /dev/random 和 /dev/urandom 的內容時');
 
     // prettier-ignore
-    expect(pangu.spacingText('當你用cat和od指令查看"/dev/random"和"/dev/urandom"的內容時'))
+    expect(pangu.spaceText('當你用cat和od指令查看"/dev/random"和"/dev/urandom"的內容時'))
                        .toBe('當你用 cat 和 od 指令查看 "/dev/random" 和 "/dev/urandom" 的內容時');
 
     // Basic Unix paths
-    expect(pangu.spacingText('在/home目錄')).toBe('在 /home 目錄');
-    expect(pangu.spacingText('查看/etc/passwd文件')).toBe('查看 /etc/passwd 文件');
-    expect(pangu.spacingText('進入/usr/local/bin目錄')).toBe('進入 /usr/local/bin 目錄');
+    expect(pangu.spaceText('在/home目錄')).toBe('在 /home 目錄');
+    expect(pangu.spaceText('查看/etc/passwd文件')).toBe('查看 /etc/passwd 文件');
+    expect(pangu.spaceText('進入/usr/local/bin目錄')).toBe('進入 /usr/local/bin 目錄');
 
     // Paths with dots
-    expect(pangu.spacingText('配置檔在/etc/nginx/nginx.conf')).toBe('配置檔在 /etc/nginx/nginx.conf');
-    expect(pangu.spacingText('隱藏檔案/.bashrc很重要')).toBe('隱藏檔案 /.bashrc 很重要');
-    expect(pangu.spacingText('查看/home/.config/settings')).toBe('查看 /home/.config/settings');
+    expect(pangu.spaceText('配置檔在/etc/nginx/nginx.conf')).toBe('配置檔在 /etc/nginx/nginx.conf');
+    expect(pangu.spaceText('隱藏檔案/.bashrc很重要')).toBe('隱藏檔案 /.bashrc 很重要');
+    expect(pangu.spaceText('查看/home/.config/settings')).toBe('查看 /home/.config/settings');
 
     // Paths with version numbers
-    expect(pangu.spacingText('安裝到/usr/lib/python3.9/')).toBe('安裝到 /usr/lib/python3.9/');
-    expect(pangu.spacingText('位於/opt/node-v16.14.0/bin')).toBe('位於 /opt/node-v16.14.0/bin');
+    expect(pangu.spaceText('安裝到/usr/lib/python3.9/')).toBe('安裝到 /usr/lib/python3.9/');
+    expect(pangu.spaceText('位於/opt/node-v16.14.0/bin')).toBe('位於 /opt/node-v16.14.0/bin');
 
     // Paths with special characters
-    expect(pangu.spacingText('備份到/mnt/backup.2024-01-01/')).toBe('備份到 /mnt/backup.2024-01-01/');
-    expect(pangu.spacingText('日誌在/var/log/app-name.log')).toBe('日誌在 /var/log/app-name.log');
+    expect(pangu.spaceText('備份到/mnt/backup.2024-01-01/')).toBe('備份到 /mnt/backup.2024-01-01/');
+    expect(pangu.spaceText('日誌在/var/log/app-name.log')).toBe('日誌在 /var/log/app-name.log');
 
     // Paths with @ symbols (npm packages)
-    expect(pangu.spacingText('模組在/node_modules/@babel/core')).toBe('模組在 /node_modules/@babel/core');
-    expect(pangu.spacingText('套件在/node_modules/@types/node')).toBe('套件在 /node_modules/@types/node');
+    expect(pangu.spaceText('模組在/node_modules/@babel/core')).toBe('模組在 /node_modules/@babel/core');
+    expect(pangu.spaceText('套件在/node_modules/@types/node')).toBe('套件在 /node_modules/@types/node');
 
     // Paths with + symbols
-    expect(pangu.spacingText('編譯器在/usr/bin/g++')).toBe('編譯器在 /usr/bin/g++');
+    expect(pangu.spaceText('編譯器在/usr/bin/g++')).toBe('編譯器在 /usr/bin/g++');
 
     // prettier-ignore
-    expect(pangu.spacingText('套件在/usr/lib/gcc/x86_64-linux-gnu/11++'))
+    expect(pangu.spaceText('套件在/usr/lib/gcc/x86_64-linux-gnu/11++'))
                            .toBe('套件在 /usr/lib/gcc/x86_64-linux-gnu/11++');
 
     // Paths ending with slash before CJK
-    expect(pangu.spacingText('目錄/usr/bin/包含執行檔')).toBe('目錄 /usr/bin/ 包含執行檔');
-    expect(pangu.spacingText('資料夾/etc/nginx/存放設定')).toBe('資料夾 /etc/nginx/ 存放設定');
+    expect(pangu.spaceText('目錄/usr/bin/包含執行檔')).toBe('目錄 /usr/bin/ 包含執行檔');
+    expect(pangu.spaceText('資料夾/etc/nginx/存放設定')).toBe('資料夾 /etc/nginx/ 存放設定');
   });
 
   it('handle / symbol as Unix relative file path', () => {
     // Basic relative paths
-    expect(pangu.spacingText('檢查src/main.py文件')).toBe('檢查 src/main.py 文件');
-    expect(pangu.spacingText('構建dist/index.js完成')).toBe('構建 dist/index.js 完成');
-    expect(pangu.spacingText('運行test/spec.js測試')).toBe('運行 test/spec.js 測試');
-    expect(pangu.spacingText('編輯docs/README.md文檔')).toBe('編輯 docs/README.md 文檔');
+    expect(pangu.spaceText('檢查src/main.py文件')).toBe('檢查 src/main.py 文件');
+    expect(pangu.spaceText('構建dist/index.js完成')).toBe('構建 dist/index.js 完成');
+    expect(pangu.spaceText('運行test/spec.js測試')).toBe('運行 test/spec.js 測試');
+    expect(pangu.spaceText('編輯docs/README.md文檔')).toBe('編輯 docs/README.md 文檔');
 
     // Project directories
-    expect(pangu.spacingText('查看templates/base.html模板')).toBe('查看 templates/base.html 模板');
-    expect(pangu.spacingText('複製assets/images/logo.png圖片')).toBe('複製 assets/images/logo.png 圖片');
-    expect(pangu.spacingText('配置config/database.yml設定')).toBe('配置 config/database.yml 設定');
-    expect(pangu.spacingText('執行scripts/deploy.sh腳本')).toBe('執行 scripts/deploy.sh 腳本');
+    expect(pangu.spaceText('查看templates/base.html模板')).toBe('查看 templates/base.html 模板');
+    expect(pangu.spaceText('複製assets/images/logo.png圖片')).toBe('複製 assets/images/logo.png 圖片');
+    expect(pangu.spaceText('配置config/database.yml設定')).toBe('配置 config/database.yml 設定');
+    expect(pangu.spaceText('執行scripts/deploy.sh腳本')).toBe('執行 scripts/deploy.sh 腳本');
 
     // Build/output directories
-    expect(pangu.spacingText('清理build/temp/目錄')).toBe('清理 build/temp/ 目錄');
-    expect(pangu.spacingText('輸出到target/release/資料夾')).toBe('輸出到 target/release/ 資料夾');
-    expect(pangu.spacingText('發布到public/static/路徑')).toBe('發布到 public/static/ 路徑');
+    expect(pangu.spaceText('清理build/temp/目錄')).toBe('清理 build/temp/ 目錄');
+    expect(pangu.spaceText('輸出到target/release/資料夾')).toBe('輸出到 target/release/ 資料夾');
+    expect(pangu.spaceText('發布到public/static/路徑')).toBe('發布到 public/static/ 路徑');
 
     // Development directories
-    expect(pangu.spacingText('安裝node_modules/@babel/core套件')).toBe('安裝 node_modules/@babel/core 套件');
-    expect(pangu.spacingText('設定.git/hooks/pre-commit鉤子')).toBe('設定 .git/hooks/pre-commit 鉤子');
-    expect(pangu.spacingText('編輯.vscode/settings.json配置')).toBe('編輯 .vscode/settings.json 配置');
+    expect(pangu.spaceText('安裝node_modules/@babel/core套件')).toBe('安裝 node_modules/@babel/core 套件');
+    expect(pangu.spaceText('設定.git/hooks/pre-commit鉤子')).toBe('設定 .git/hooks/pre-commit 鉤子');
+    expect(pangu.spaceText('編輯.vscode/settings.json配置')).toBe('編輯 .vscode/settings.json 配置');
 
     // With leading ./
-    expect(pangu.spacingText('參考./docs/API.md文件')).toBe('參考 ./docs/API.md 文件');
-    expect(pangu.spacingText('執行./scripts/test.sh腳本')).toBe('執行 ./scripts/test.sh 腳本');
-    expect(pangu.spacingText('查看./.claude/CLAUDE.md說明')).toBe('查看 ./.claude/CLAUDE.md 說明');
+    expect(pangu.spaceText('參考./docs/API.md文件')).toBe('參考 ./docs/API.md 文件');
+    expect(pangu.spaceText('執行./scripts/test.sh腳本')).toBe('執行 ./scripts/test.sh 腳本');
+    expect(pangu.spaceText('查看./.claude/CLAUDE.md說明')).toBe('查看 ./.claude/CLAUDE.md 說明');
 
     // Nested paths
-    expect(pangu.spacingText('位於src/components/Button/index.tsx')).toBe('位於 src/components/Button/index.tsx');
-    expect(pangu.spacingText('存放在assets/fonts/Inter/Regular.woff2')).toBe('存放在 assets/fonts/Inter/Regular.woff2');
+    expect(pangu.spaceText('位於src/components/Button/index.tsx')).toBe('位於 src/components/Button/index.tsx');
+    expect(pangu.spaceText('存放在assets/fonts/Inter/Regular.woff2')).toBe('存放在 assets/fonts/Inter/Regular.woff2');
 
     // Multiple file paths in one sentence
-    expect(pangu.spacingText('從src/utils.js複製到dist/utils.js')).toBe('從 src/utils.js 複製到 dist/utils.js');
-    expect(pangu.spacingText('比較test/fixtures/input.txt和test/fixtures/output.txt')).toBe('比較 test/fixtures/input.txt 和 test/fixtures/output.txt');
+    expect(pangu.spaceText('從src/utils.js複製到dist/utils.js')).toBe('從 src/utils.js 複製到 dist/utils.js');
+    expect(pangu.spaceText('比較test/fixtures/input.txt和test/fixtures/output.txt')).toBe('比較 test/fixtures/input.txt 和 test/fixtures/output.txt');
   });
 
   it('handle / symbol as glob pattern', () => {
-    expect(pangu.spacingText('聽說桐島rm -rf /*了')).toBe('聽說桐島 rm -rf /* 了');
-    expect(pangu.spacingText('模板在templates/*.html裡')).toBe('模板在 templates/*.html 裡');
-    expect(pangu.spacingText('測試所有test/**/*.js檔案')).toBe('測試所有 test/**/*.js 檔案');
+    expect(pangu.spaceText('聽說桐島rm -rf /*了')).toBe('聽說桐島 rm -rf /* 了');
+    expect(pangu.spaceText('模板在templates/*.html裡')).toBe('模板在 templates/*.html 裡');
+    expect(pangu.spaceText('測試所有test/**/*.js檔案')).toBe('測試所有 test/**/*.js 檔案');
   });
 });

--- a/tests/shared/symbol-square-brackets.test.ts
+++ b/tests/shared/symbol-square-brackets.test.ts
@@ -5,17 +5,17 @@ const pangu = new Pangu();
 
 describe('Symbol [ ]', () => {
   it('handle [ ] symbols as square brackets', () => {
-    expect(pangu.spacingText('前面[中文123漢字]後面')).toBe('前面 [中文 123 漢字] 後面');
-    expect(pangu.spacingText('前面[中文123]後面')).toBe('前面 [中文 123] 後面');
-    expect(pangu.spacingText('前面[123漢字]後面')).toBe('前面 [123 漢字] 後面');
-    expect(pangu.spacingText('前面[中文123] tail')).toBe('前面 [中文 123] tail');
-    expect(pangu.spacingText('head [中文123漢字]後面')).toBe('head [中文 123 漢字] 後面');
-    expect(pangu.spacingText('head [中文123漢字] tail')).toBe('head [中文 123 漢字] tail');
+    expect(pangu.spaceText('前面[中文123漢字]後面')).toBe('前面 [中文 123 漢字] 後面');
+    expect(pangu.spaceText('前面[中文123]後面')).toBe('前面 [中文 123] 後面');
+    expect(pangu.spaceText('前面[123漢字]後面')).toBe('前面 [123 漢字] 後面');
+    expect(pangu.spaceText('前面[中文123] tail')).toBe('前面 [中文 123] tail');
+    expect(pangu.spaceText('head [中文123漢字]後面')).toBe('head [中文 123 漢字] 後面');
+    expect(pangu.spaceText('head [中文123漢字] tail')).toBe('head [中文 123 漢字] tail');
   });
 
   it('handle multiline content in square brackets', () => {
     // A space before a newline is mid-content, not a bracket-edge space: only the literal string edges get stripped
-    expect(pangu.spacingText('[x \n]中')).toBe('[x \n] 中');
-    expect(pangu.spacingText('中[ 多行\n內容 ]')).toBe('中 [多行\n內容]');
+    expect(pangu.spaceText('[x \n]中')).toBe('[x \n] 中');
+    expect(pangu.spaceText('中[ 多行\n內容 ]')).toBe('中 [多行\n內容]');
   });
 });

--- a/tests/shared/symbol-superscript.test.ts
+++ b/tests/shared/symbol-superscript.test.ts
@@ -5,45 +5,45 @@ const pangu = new Pangu();
 
 describe('Symbol Superscripts', () => {
   it('handle superscript as suffix', () => {
-    expect(pangu.spacingText('前面E=mc²後面')).toBe('前面 E=mc² 後面');
+    expect(pangu.spaceText('前面E=mc²後面')).toBe('前面 E=mc² 後面');
 
     // prettier-ignore
-    expect(pangu.spacingText('115年賽事加碼：7/21-10/8 新申請MOD+自選餐(全選)/影劇館⁺加碼'))
+    expect(pangu.spaceText('115年賽事加碼：7/21-10/8 新申請MOD+自選餐(全選)/影劇館⁺加碼'))
                        .toBe('115 年賽事加碼：7/21-10/8 新申請 MOD + 自選餐 (全選)/影劇館⁺ 加碼');
 
-    expect(pangu.spacingText('甲⁰乙、甲¹乙、甲²乙、甲³乙、甲⁴乙、甲⁵乙、甲⁶乙、甲⁷乙、甲⁸乙、甲⁹乙')).toBe('甲⁰ 乙、甲¹ 乙、甲² 乙、甲³ 乙、甲⁴ 乙、甲⁵ 乙、甲⁶ 乙、甲⁷ 乙、甲⁸ 乙、甲⁹ 乙');
-    expect(pangu.spacingText('甲ⁱ乙、甲ⁿ乙、甲⁺乙、甲⁻乙、甲⁼乙')).toBe('甲ⁱ 乙、甲ⁿ 乙、甲⁺ 乙、甲⁻ 乙、甲⁼ 乙');
-    expect(pangu.spacingText('甲⁽註⁾乙')).toBe('甲⁽註⁾ 乙');
+    expect(pangu.spaceText('甲⁰乙、甲¹乙、甲²乙、甲³乙、甲⁴乙、甲⁵乙、甲⁶乙、甲⁷乙、甲⁸乙、甲⁹乙')).toBe('甲⁰ 乙、甲¹ 乙、甲² 乙、甲³ 乙、甲⁴ 乙、甲⁵ 乙、甲⁶ 乙、甲⁷ 乙、甲⁸ 乙、甲⁹ 乙');
+    expect(pangu.spaceText('甲ⁱ乙、甲ⁿ乙、甲⁺乙、甲⁻乙、甲⁼乙')).toBe('甲ⁱ 乙、甲ⁿ 乙、甲⁺ 乙、甲⁻ 乙、甲⁼ 乙');
+    expect(pangu.spaceText('甲⁽註⁾乙')).toBe('甲⁽註⁾ 乙');
   });
 
   // \u2122
   it('handle ™ symbol', () => {
-    expect(pangu.spacingText('Trademark™後面')).toBe('Trademark™ 後面');
-    expect(pangu.spacingText('商標™後面')).toBe('商標™ 後面');
+    expect(pangu.spaceText('Trademark™後面')).toBe('Trademark™ 後面');
+    expect(pangu.spaceText('商標™後面')).toBe('商標™ 後面');
   });
 
   // \u2120
   it('handle ℠ symbol', () => {
-    expect(pangu.spacingText('Service Mark℠後面')).toBe('Service Mark℠ 後面');
-    expect(pangu.spacingText('服務商標℠後面')).toBe('服務商標℠ 後面');
+    expect(pangu.spaceText('Service Mark℠後面')).toBe('Service Mark℠ 後面');
+    expect(pangu.spaceText('服務商標℠後面')).toBe('服務商標℠ 後面');
   });
 });
 
 // \u00ae
 describe('Symbol ®', () => {
   it('handle ® symbol', () => {
-    expect(pangu.spacingText('Registered Trademark®後面')).toBe('Registered Trademark® 後面');
-    expect(pangu.spacingText('註冊商標®公司')).toBe('註冊商標® 公司');
-    expect(pangu.spacingText('註冊商標®與Trademark™')).toBe('註冊商標® 與 Trademark™');
+    expect(pangu.spaceText('Registered Trademark®後面')).toBe('Registered Trademark® 後面');
+    expect(pangu.spaceText('註冊商標®公司')).toBe('註冊商標® 公司');
+    expect(pangu.spaceText('註冊商標®與Trademark™')).toBe('註冊商標® 與 Trademark™');
   });
 });
 
 // \u00a9
 describe('Symbol ©', () => {
   it('handle © symbol', () => {
-    expect(pangu.spacingText('版權所有©2026東亞重工')).toBe('版權所有 © 2026 東亞重工');
-    expect(pangu.spacingText('版權所有©2012-2026東亞重工')).toBe('版權所有 © 2012-2026 東亞重工');
-    expect(pangu.spacingText('Copyright © 2026東亞重工')).toBe('Copyright © 2026 東亞重工');
-    expect(pangu.spacingText('Copyright © 2012-2026東亞重工')).toBe('Copyright © 2012-2026 東亞重工');
+    expect(pangu.spaceText('版權所有©2026東亞重工')).toBe('版權所有 © 2026 東亞重工');
+    expect(pangu.spaceText('版權所有©2012-2026東亞重工')).toBe('版權所有 © 2012-2026 東亞重工');
+    expect(pangu.spaceText('Copyright © 2026東亞重工')).toBe('Copyright © 2026 東亞重工');
+    expect(pangu.spaceText('Copyright © 2012-2026東亞重工')).toBe('Copyright © 2012-2026 東亞重工');
   });
 });

--- a/tests/shared/symbol-tilde.test.ts
+++ b/tests/shared/symbol-tilde.test.ts
@@ -5,23 +5,23 @@ const pangu = new Pangu();
 
 describe('Symbol ~', () => {
   it('handle ~ symbol', () => {
-    expect(pangu.spacingText('前面~')).toBe('前面~');
-    expect(pangu.spacingText('前面~~')).toBe('前面~~');
-    expect(pangu.spacingText('前面~~~')).toBe('前面~~~');
-    expect(pangu.spacingText('前面~後面')).toBe('前面~ 後面');
-    expect(pangu.spacingText('前面~~後面')).toBe('前面~~ 後面');
-    expect(pangu.spacingText('前面~~~後面')).toBe('前面~~~ 後面');
-    expect(pangu.spacingText('前面~abc')).toBe('前面~ abc');
-    expect(pangu.spacingText('前面~123')).toBe('前面~ 123');
+    expect(pangu.spaceText('前面~')).toBe('前面~');
+    expect(pangu.spaceText('前面~~')).toBe('前面~~');
+    expect(pangu.spaceText('前面~~~')).toBe('前面~~~');
+    expect(pangu.spaceText('前面~後面')).toBe('前面~ 後面');
+    expect(pangu.spaceText('前面~~後面')).toBe('前面~~ 後面');
+    expect(pangu.spaceText('前面~~~後面')).toBe('前面~~~ 後面');
+    expect(pangu.spaceText('前面~abc')).toBe('前面~ abc');
+    expect(pangu.spaceText('前面~123')).toBe('前面~ 123');
 
     // DO NOT change if already spacing
-    expect(pangu.spacingText('前面 ~ 後面')).toBe('前面 ~ 後面');
-    expect(pangu.spacingText('前面~ 後面')).toBe('前面~ 後面');
-    expect(pangu.spacingText('前面 ~後面')).toBe('前面 ~後面');
+    expect(pangu.spaceText('前面 ~ 後面')).toBe('前面 ~ 後面');
+    expect(pangu.spaceText('前面~ 後面')).toBe('前面~ 後面');
+    expect(pangu.spaceText('前面 ~後面')).toBe('前面 ~後面');
   });
 
   it('handle ~ symbol as preserved pattern', () => {
-    expect(pangu.spacingText('前面~=後面')).toBe('前面 ~= 後面');
-    expect(pangu.spacingText('前面 ~= 後面')).toBe('前面 ~= 後面');
+    expect(pangu.spaceText('前面~=後面')).toBe('前面 ~= 後面');
+    expect(pangu.spaceText('前面 ~= 後面')).toBe('前面 ~= 後面');
   });
 });

--- a/tests/shared/symbol-underscore.test.ts
+++ b/tests/shared/symbol-underscore.test.ts
@@ -5,28 +5,28 @@ const pangu = new Pangu();
 
 describe('Symbol _', () => {
   it('handle _ symbol as separator', () => {
-    expect(pangu.spacingText('前面_後面')).toBe('前面_後面');
-    expect(pangu.spacingText('Vinta_Mollie')).toBe('Vinta_Mollie');
-    expect(pangu.spacingText('Vinta_Mollie_Kitten')).toBe('Vinta_Mollie_Kitten');
-    expect(pangu.spacingText('Mollie_陳上進')).toBe('Mollie_陳上進');
-    expect(pangu.spacingText('陳上進_Mollie')).toBe('陳上進_Mollie');
-    expect(pangu.spacingText('陳上進_貓咪_Mollie')).toBe('陳上進_貓咪_Mollie');
-    expect(pangu.spacingText('陳上進_Mollie_貓咪')).toBe('陳上進_Mollie_貓咪');
-    expect(pangu.spacingText('Mollie_Vinta_貓咪')).toBe('Mollie_Vinta_貓咪');
-    expect(pangu.spacingText('Mollie_陳上進_貓咪')).toBe('Mollie_陳上進_貓咪');
-    expect(pangu.spacingText('得到一個A_B的結果')).toBe('得到一個 A_B 的結果');
+    expect(pangu.spaceText('前面_後面')).toBe('前面_後面');
+    expect(pangu.spaceText('Vinta_Mollie')).toBe('Vinta_Mollie');
+    expect(pangu.spaceText('Vinta_Mollie_Kitten')).toBe('Vinta_Mollie_Kitten');
+    expect(pangu.spaceText('Mollie_陳上進')).toBe('Mollie_陳上進');
+    expect(pangu.spaceText('陳上進_Mollie')).toBe('陳上進_Mollie');
+    expect(pangu.spaceText('陳上進_貓咪_Mollie')).toBe('陳上進_貓咪_Mollie');
+    expect(pangu.spaceText('陳上進_Mollie_貓咪')).toBe('陳上進_Mollie_貓咪');
+    expect(pangu.spaceText('Mollie_Vinta_貓咪')).toBe('Mollie_Vinta_貓咪');
+    expect(pangu.spaceText('Mollie_陳上進_貓咪')).toBe('Mollie_陳上進_貓咪');
+    expect(pangu.spaceText('得到一個A_B的結果')).toBe('得到一個 A_B 的結果');
 
     // prettier-ignore
-    expect(pangu.spacingText('為什麼你們就是不能加個空格呢？_20771210_最終版_v365.7.24.zip'))
+    expect(pangu.spaceText('為什麼你們就是不能加個空格呢？_20771210_最終版_v365.7.24.zip'))
                        .toBe('為什麼你們就是不能加個空格呢？_20771210_最終版_v365.7.24.zip');
 
     // Rare cases, ignore
-    // expect(pangu.spacingText('前面 _ 後面')).toBe('前面 _ 後面');
-    // expect(pangu.spacingText('Vinta _ Mollie')).toBe('Vinta _ Mollie');
-    // expect(pangu.spacingText('Vinta _ Mollie _ Kitten')).toBe('Vinta _ Mollie _ Kitten');
-    // expect(pangu.spacingText('陳上進 _ 貓咪 _ Mollie')).toBe('陳上進 _ 貓咪 _ Mollie');
-    // expect(pangu.spacingText('陳上進 _ Mollie _ 貓咪')).toBe('陳上進 _ Mollie _ 貓咪');
-    // expect(pangu.spacingText('Mollie _ Vinta _ 貓咪')).toBe('Mollie _ Vinta _ 貓咪');
-    // expect(pangu.spacingText('Mollie _ 陳上進 _ 貓咪')).toBe('Mollie _ 陳上進 _ 貓咪');
+    // expect(pangu.spaceText('前面 _ 後面')).toBe('前面 _ 後面');
+    // expect(pangu.spaceText('Vinta _ Mollie')).toBe('Vinta _ Mollie');
+    // expect(pangu.spaceText('Vinta _ Mollie _ Kitten')).toBe('Vinta _ Mollie _ Kitten');
+    // expect(pangu.spaceText('陳上進 _ 貓咪 _ Mollie')).toBe('陳上進 _ 貓咪 _ Mollie');
+    // expect(pangu.spaceText('陳上進 _ Mollie _ 貓咪')).toBe('陳上進 _ Mollie _ 貓咪');
+    // expect(pangu.spaceText('Mollie _ Vinta _ 貓咪')).toBe('Mollie _ Vinta _ 貓咪');
+    // expect(pangu.spaceText('Mollie _ 陳上進 _ 貓咪')).toBe('Mollie _ 陳上進 _ 貓咪');
   });
 });


### PR DESCRIPTION
Renames the public API from gerund to verb form: `spacingText` to `spaceText`, `spacingFile`/`spacingFileSync` to `spaceFile`/`spaceFileSync`, `spacingPage` to `spacePage`, `spacingNode` to `spaceNode`, `autoSpacingPage`/`stopAutoSpacingPage` to `autoSpacePage`/`stopAutoSpacePage`, and the `AutoSpacingPageConfig` type to `AutoSpacePageConfig`. No deprecated aliases. Updates every call site across `src/`, `browser-extensions/chrome/src/content-script.ts`, the examples, `README.md`, `CONTEXT.md`, and all `tests/` suites.

Follow-ups in the same branch: the rules' `Verdict` types become `Decision`, with a matching entry added to `CONTEXT.md`, and the CLI helpers `printSpaceText`/`printSpaceFile` become `spaceTextPrinted`/`spaceFilePrinted` in `src/node/cli.ts`. It also drops `isAutoSpacePageExecuted` and an unreachable `disconnect` call from `src/browser/pangu.ts`, updates `CHANGELOG.md`, fixes a stale `shouldAutoSpacing()` reference in ADR 0020, corrects README line 98, and prunes `CONTEXT.md`'s Avoid lists.
