### PR TITLE
Parse URL filters as Chrome match patterns before URLPattern

### DIFF
--- a/browser-extensions/chrome/src/settings/urls.ts
+++ b/browser-extensions/chrome/src/settings/urls.ts
@@ -8,7 +8,7 @@ function escapeUrlPatternSyntax(part: string) {
   return part.replace(/[(){}:+?\\]/g, '\\$&');
 }
 
-// The string form of URLPattern reads `*.host` as subdomains only and pins a missing port to the scheme default, so the init form carries the match pattern's meaning instead
+// The string form of URLPattern reads a host wildcard (`*.example.com`) as subdomains only and pins a missing port to the scheme default, so the init form carries the match pattern's meaning instead
 function matchPatternToUrlPattern(pattern: string): URLPattern | null {
   const match = MATCH_PATTERN.exec(pattern);
   if (!match) {

--- a/browser-extensions/chrome/src/settings/urls.ts
+++ b/browser-extensions/chrome/src/settings/urls.ts
@@ -1,20 +1,34 @@
 import type { Settings } from './storage';
 
-export function isValidMatchPattern(pattern: string) {
-  // We only allow:
-  // https://
-  // http://
-  // *://
-  if (!pattern.match(/^(https?:\/\/|\*:\/\/)/)) {
-    return false;
-  }
+// Chrome match pattern grammar, in the subset ADR 0023 keeps: <scheme>://<host>[:<port>]<path>
+const MATCH_PATTERN = /^(\*|https?):\/\/(\*|(?:\*\.)?[^/*:?]+)(?::(\*|\d+))?(\/[^?]*)$/;
 
-  try {
-    new URLPattern(pattern);
-    return true;
-  } catch {
-    return false;
+// A match pattern reads every character except `*` literally, so URLPattern's own syntax gets escaped
+function escapeUrlPatternSyntax(path: string) {
+  return path.replace(/[(){}:+\\]/g, '\\$&');
+}
+
+// The string form of URLPattern reads `*.host` as subdomains only and pins a missing port to the scheme default, so the init form carries the match pattern's meaning instead
+function matchPatternToUrlPattern(pattern: string): URLPattern | null {
+  const match = MATCH_PATTERN.exec(pattern);
+  if (!match) {
+    return null;
   }
+  const [, scheme = '', host = '', port, path = ''] = match;
+  try {
+    return new URLPattern({
+      protocol: scheme === '*' ? 'http{s}?' : scheme,
+      hostname: host.startsWith('*.') ? `{*.}?${host.slice(2)}` : host,
+      port: port ?? '*',
+      pathname: escapeUrlPatternSyntax(path),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function isValidMatchPattern(pattern: string) {
+  return matchPatternToUrlPattern(pattern) !== null;
 }
 
 export function isValidUrl(url: string) {
@@ -24,17 +38,12 @@ export function isValidUrl(url: string) {
 }
 
 function isUrlExcludedByFilter(settings: Settings, url: string) {
-  const urlPatterns = settings[settings.filter_mode];
-  for (const pattern of urlPatterns) {
-    try {
-      const urlPattern = new URLPattern(pattern);
-      if (urlPattern.test(url)) {
-        // If URL matches blacklist, it is excluded
-        // If URL matches whitelist, it is not excluded
-        return settings.filter_mode === 'blacklist';
-      }
-    } catch {
-      // Invalid pattern, skip
+  for (const pattern of settings[settings.filter_mode]) {
+    // An invalid pattern is skipped
+    if (matchPatternToUrlPattern(pattern)?.test(url)) {
+      // If URL matches blacklist, it is excluded
+      // If URL matches whitelist, it is not excluded
+      return settings.filter_mode === 'blacklist';
     }
   }
 

--- a/browser-extensions/chrome/src/settings/urls.ts
+++ b/browser-extensions/chrome/src/settings/urls.ts
@@ -8,7 +8,6 @@ function escapeUrlPatternSyntax(part: string) {
   return part.replace(/[(){}:+?\\]/g, '\\$&');
 }
 
-// The string form of URLPattern reads a host wildcard (`*.example.com`) as subdomains only and pins a missing port to the scheme default, so the init form carries the match pattern's meaning instead
 function matchPatternToUrlPattern(pattern: string): URLPattern | null {
   const match = MATCH_PATTERN.exec(pattern);
   if (!match) {
@@ -18,7 +17,9 @@ function matchPatternToUrlPattern(pattern: string): URLPattern | null {
   try {
     return new URLPattern({
       protocol: scheme === '*' ? 'http{s}?' : scheme,
+      // Make the subdomain and its dot optional so `*.example.com` also matches `example.com`
       hostname: host.startsWith('*.') ? `{*.}?${host.slice(2)}` : host,
+      // Chrome match patterns allow any port when omitted, including non-default ports like 8443
       port: port ?? '*',
       pathname: escapeUrlPatternSyntax(path),
       // Chrome matches the path against path plus query. URLPattern matches the query on its own, so `/search?*` also matches a bare `/search`
@@ -41,7 +42,6 @@ export function isValidUrl(url: string) {
 
 function isUrlExcludedByFilter(settings: Settings, url: string) {
   for (const pattern of settings[settings.filter_mode]) {
-    // An invalid pattern is skipped
     if (matchPatternToUrlPattern(pattern)?.test(url)) {
       // If URL matches blacklist, it is excluded
       // If URL matches whitelist, it is not excluded
@@ -49,9 +49,9 @@ function isUrlExcludedByFilter(settings: Settings, url: string) {
     }
   }
 
-  // If no patterns matched:
-  // - For blacklist mode: not excluded (not blacklisted)
-  // - For whitelist mode: excluded (not whitelisted)
+  // If no valid pattern matched:
+  // - Blacklist mode: allowed
+  // - Whitelist mode: blocked
   return settings.filter_mode === 'whitelist';
 }
 

--- a/browser-extensions/chrome/src/settings/urls.ts
+++ b/browser-extensions/chrome/src/settings/urls.ts
@@ -1,11 +1,11 @@
 import type { Settings } from './storage';
 
 // Chrome match pattern grammar, in the subset ADR 0023 keeps: <scheme>://<host>[:<port>]<path>
-const MATCH_PATTERN = /^(\*|https?):\/\/(\*|(?:\*\.)?[^/*:?]+)(?::(\*|\d+))?(\/[^?]*)$/;
+const MATCH_PATTERN = /^(\*|https?):\/\/(\*|(?:\*\.)?[^/*:?]+)(?::(\*|\d+))?(\/[^?]*)(?:\?(.*))?$/;
 
 // A match pattern reads every character except `*` literally, so URLPattern's own syntax gets escaped
-function escapeUrlPatternSyntax(path: string) {
-  return path.replace(/[(){}:+\\]/g, '\\$&');
+function escapeUrlPatternSyntax(part: string) {
+  return part.replace(/[(){}:+?\\]/g, '\\$&');
 }
 
 // The string form of URLPattern reads `*.host` as subdomains only and pins a missing port to the scheme default, so the init form carries the match pattern's meaning instead
@@ -14,13 +14,15 @@ function matchPatternToUrlPattern(pattern: string): URLPattern | null {
   if (!match) {
     return null;
   }
-  const [, scheme = '', host = '', port, path = ''] = match;
+  const [, scheme = '', host = '', port, path = '', query] = match;
   try {
     return new URLPattern({
       protocol: scheme === '*' ? 'http{s}?' : scheme,
       hostname: host.startsWith('*.') ? `{*.}?${host.slice(2)}` : host,
       port: port ?? '*',
       pathname: escapeUrlPatternSyntax(path),
+      // Chrome matches the path against path plus query. URLPattern matches the query on its own, so `/search?*` also matches a bare `/search`
+      search: query === undefined ? '*' : escapeUrlPatternSyntax(query),
     });
   } catch {
     return null;

--- a/docs/adr/0022-plus-after-a-closing-bracket-reads-as-a-separator.md
+++ b/docs/adr/0022-plus-after-a-closing-bracket-reads-as-a-separator.md
@@ -1,4 +1,4 @@
-# A plus after a closing bracket reads as a separator before a full-width opener
+# A plus after a closing bracket reads as a separator
 
 Plus reading keeps a plus tight on the side that touches common Chinese full-width punctuation, even when another plus flips the line. The reason is a name: in `Disney+（迪士尼）` or `影劇館+」` the plus is a suffix that the extension's name-suffix list restores per ADR 0019, and a space before an opening full-width bracket or quote would split the name from its gloss.
 

--- a/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
+++ b/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
@@ -1,0 +1,29 @@
+# URL filters accept a subset of Chrome match patterns, translated into URLPattern
+
+The options page tells users they can use `*` in a URL and links to Chrome's match pattern docs. Until 9.1.1, Chrome read the entries itself: the DOM content script carried the blacklist as `excludeMatches` and the whitelist as `matches`. [ADR 0020](0020-site-filters-follow-same-document-navigation.md) moved the decision into the content script, which reads the entries through `URLPattern`, as the popup status row and the icon had done since 2025-07. `URLPattern` is not a match pattern parser. Fed the same string, it disagrees on two shapes: `*://*.example.com/*` does not match `https://example.com/`, and `https://example.com/*` does not match `https://example.com:8443/`. Before ADR 0020 the disagreement only mislabeled the popup and the icon. After it, a saved entry with `*.` stops excluding or allowing the apex host.
+
+The decisions:
+
+1. **An entry is a Chrome match pattern in this subset: `<scheme>://<host>[:<port>]<path>`.**
+   - scheme: `http`, `https`, or `*` for either.
+   - host: `*` for any host, `*.example.com` for the host and every subdomain, or one exact host (a domain, `localhost`, an IPv4 address).
+   - port: optional. `:3000` for one port, `:*` or nothing for any port.
+   - path: required, starts with `/`. `*` matches any characters, every other character is literal.
+
+   Everything else Chrome accepts is rejected: `<all_urls>`, `file://`, `ftp://`, `ws://`, `wss://`, `urn:`, `chrome-extension://`, bracketed IPv6 hosts, `*` inside a host except a leading `*.`, an entry with no path, and a `?` query part. The content script never runs on those schemes, Chrome rejects most of the rest, and nobody has asked to filter by query.
+
+2. **One function translates an entry into a `URLPattern` init dict that carries Chrome's meaning.** The `*` scheme becomes `http{s}?`. `*.example.com` becomes `{*.}?example.com`, MDN's own example for a domain and its subdomains. A missing port becomes `*`. The path becomes `pathname` with `URLPattern`'s own syntax characters escaped, so `C++` and `(programming_language)` stay literal. Validation on the options page and matching in the content script, the popup, and the icon all go through this function.
+
+Alternatives rejected:
+
+- `webext-patterns`, which converts match patterns to a RegExp: correct, but a dependency for one function.
+- A hand-rolled RegExp replacing `URLPattern`: more code to own for no gain.
+- Reverting ADR 0020: brings back the same-document navigation bug on GitHub for every default install, to protect a rare shape.
+
+## Consequences
+
+- Saved entries with `*.` or a port behave as they did in 9.1.1, when Chrome read them.
+- An entry with no path, such as `https://example.com`, turns from accepted into invalid. Through `URLPattern` it matched the whole host; in 9.1.1 it broke the DOM script registration, so no such entry ever worked in a release.
+- An entry with a query part, such as `https://www.google.com/search?*`, turns from accepted into invalid too. Chrome and the string form of `URLPattern` both read it, so a saved one did work before.
+- The popup status row and the icon stop mislabeling `*.` entries, since they share the function.
+- `tests/browser/urlpattern.playwright.ts` keeps testing raw `URLPattern`, including the apex mismatch. It records why the translation exists.

--- a/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
+++ b/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
@@ -10,7 +10,7 @@ The decisions:
    - port: optional. `:3000` for one port, `:*` or nothing for any port.
    - path: required, starts with `/`. `*` matches any characters, every other character is literal. A `?` starts the query part.
 
-   Everything else Chrome accepts is rejected: `<all_urls>`, `file://`, `ftp://`, `ws://`, `wss://`, `urn:`, `chrome-extension://`, bracketed IPv6 hosts, `*` inside a host except a leading `*.`, and an entry with no path. The content script never runs on those schemes, and Chrome rejects the rest too.
+   Everything else Chrome accepts is rejected: `<all_urls>`, `file://`, `ftp://`, `ws://`, `wss://`, `urn:`, `chrome-extension://`, bracketed IPv6 hosts, `*` inside a host except a leading `*.`, and an entry with no path. The content script never runs on those schemes. Chrome rejects a mid-host `*` and a missing path, and the old validator never accepted an IPv6 host, so no synced entry of those shapes exists.
 
 2. **One function translates an entry into a `URLPattern` init dict that carries Chrome's meaning.** The `*` scheme becomes `http{s}?`. `*.example.com` becomes `{*.}?example.com`, MDN's own example for a domain and its subdomains. A missing port becomes `*`. The path splits at the first `?` into `pathname` and `search`, with `URLPattern`'s own syntax characters escaped so `C++` and `(programming_language)` stay literal. Validation on the options page and matching in the content script, the popup, and the icon all go through this function.
 

--- a/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
+++ b/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
@@ -18,7 +18,7 @@ Alternatives rejected:
 
 - `webext-patterns`, which converts match patterns to a RegExp: correct, but a dependency for one function.
 - A hand-rolled RegExp replacing `URLPattern`: more code to own for no gain.
-- `chrome.tabs.query({ url })`, which matches tabs with Chrome's own grammar and throws on an invalid pattern. Probed from the worker on 2026-09-10: it reads `*.host` and ports as Chrome does, and the tab URL is already updated when the content script reacts to `currententrychange`. Rejected because the content script cannot call it: the URL policy becomes a message hop and an async wait with a stale-response guard, `url: []` matches every tab, and one invalid entry throws the whole call. Same line count as the parser, spread over four files.
+- `chrome.tabs.query({ url })`, which matches tabs with Chrome's own grammar and throws on an invalid pattern. Probed from the worker on 2026-09-10: it reads a host wildcard (`*.example.com`) and ports as Chrome does, and the tab URL is already updated when the content script reacts to `currententrychange`. Rejected because the content script cannot call it: the URL policy becomes a message hop and an async wait with a stale-response guard, `url: []` matches every tab, and one invalid entry throws the whole call. Same line count as the parser, spread over four files.
 - Reverting ADR 0020: brings back the same-document navigation bug on GitHub for every default install, to protect a rare shape.
 
 ## Consequences

--- a/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
+++ b/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
@@ -18,6 +18,7 @@ Alternatives rejected:
 
 - `webext-patterns`, which converts match patterns to a RegExp: correct, but a dependency for one function.
 - A hand-rolled RegExp replacing `URLPattern`: more code to own for no gain.
+- `chrome.tabs.query({ url })`, which matches tabs with Chrome's own grammar and throws on an invalid pattern. Probed from the worker on 2026-09-10: it reads `*.host` and ports as Chrome does, and the tab URL is already updated when the content script reacts to `currententrychange`. Rejected because the content script cannot call it: the URL policy becomes a message hop and an async wait with a stale-response guard, `url: []` matches every tab, and one invalid entry throws the whole call. Same line count as the parser, spread over four files.
 - Reverting ADR 0020: brings back the same-document navigation bug on GitHub for every default install, to protect a rare shape.
 
 ## Consequences

--- a/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
+++ b/docs/adr/0023-url-filters-accept-a-subset-of-chrome-match-patterns.md
@@ -8,11 +8,11 @@ The decisions:
    - scheme: `http`, `https`, or `*` for either.
    - host: `*` for any host, `*.example.com` for the host and every subdomain, or one exact host (a domain, `localhost`, an IPv4 address).
    - port: optional. `:3000` for one port, `:*` or nothing for any port.
-   - path: required, starts with `/`. `*` matches any characters, every other character is literal.
+   - path: required, starts with `/`. `*` matches any characters, every other character is literal. A `?` starts the query part.
 
-   Everything else Chrome accepts is rejected: `<all_urls>`, `file://`, `ftp://`, `ws://`, `wss://`, `urn:`, `chrome-extension://`, bracketed IPv6 hosts, `*` inside a host except a leading `*.`, an entry with no path, and a `?` query part. The content script never runs on those schemes, Chrome rejects most of the rest, and nobody has asked to filter by query.
+   Everything else Chrome accepts is rejected: `<all_urls>`, `file://`, `ftp://`, `ws://`, `wss://`, `urn:`, `chrome-extension://`, bracketed IPv6 hosts, `*` inside a host except a leading `*.`, and an entry with no path. The content script never runs on those schemes, and Chrome rejects the rest too.
 
-2. **One function translates an entry into a `URLPattern` init dict that carries Chrome's meaning.** The `*` scheme becomes `http{s}?`. `*.example.com` becomes `{*.}?example.com`, MDN's own example for a domain and its subdomains. A missing port becomes `*`. The path becomes `pathname` with `URLPattern`'s own syntax characters escaped, so `C++` and `(programming_language)` stay literal. Validation on the options page and matching in the content script, the popup, and the icon all go through this function.
+2. **One function translates an entry into a `URLPattern` init dict that carries Chrome's meaning.** The `*` scheme becomes `http{s}?`. `*.example.com` becomes `{*.}?example.com`, MDN's own example for a domain and its subdomains. A missing port becomes `*`. The path splits at the first `?` into `pathname` and `search`, with `URLPattern`'s own syntax characters escaped so `C++` and `(programming_language)` stay literal. Validation on the options page and matching in the content script, the popup, and the icon all go through this function.
 
 Alternatives rejected:
 
@@ -25,6 +25,7 @@ Alternatives rejected:
 
 - Saved entries with `*.` or a port behave as they did in 9.1.1, when Chrome read them.
 - An entry with no path, such as `https://example.com`, turns from accepted into invalid. Through `URLPattern` it matched the whole host; in 9.1.1 it broke the DOM script registration, so no such entry ever worked in a release.
-- An entry with a query part, such as `https://www.google.com/search?*`, turns from accepted into invalid too. Chrome and the string form of `URLPattern` both read it, so a saved one did work before.
+- The query part is matched on its own, so `https://www.google.com/search?*` also matches the bare `/search`. Chrome would not. Lenient only.
+- Every entry that worked in 9.1.1 keeps working. The rejected shapes broke Chrome's registration or failed the old validator, so no synced entry of those shapes ever filtered a page.
 - The popup status row and the icon stop mislabeling `*.` entries, since they share the function.
 - `tests/browser/urlpattern.playwright.ts` keeps testing raw `URLPattern`, including the apex mismatch. It records why the translation exists.

--- a/tests/extension/urls.test.ts
+++ b/tests/extension/urls.test.ts
@@ -129,7 +129,7 @@ describe('shouldAutoSpace', () => {
     expect(shouldAutoSpace(current, 'https://other.com/')).toBe(false);
   });
 
-  it('reads `*.host` as the host and every subdomain, as Chrome does', () => {
+  it('reads a host wildcard as the host and every subdomain, as Chrome does', () => {
     const current = makeSettings({ blacklist: ['*://*.example.com/*'] });
     expect(shouldAutoSpace(current, 'https://example.com/')).toBe(false);
     expect(shouldAutoSpace(current, 'https://www.example.com/')).toBe(false);

--- a/tests/extension/urls.test.ts
+++ b/tests/extension/urls.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_SETTINGS, type Settings } from '../../browser-extensions/chrome/src/settings/storage';
-import { isValidUrl, shouldAutoSpace, shouldShowActiveStatus, shouldShowOffIcon } from '../../browser-extensions/chrome/src/settings/urls';
+import { isValidMatchPattern, isValidUrl, shouldAutoSpace, shouldShowActiveStatus, shouldShowOffIcon } from '../../browser-extensions/chrome/src/settings/urls';
 
 function makeSettings(overrides: Partial<Settings> = {}): Settings {
   return { ...DEFAULT_SETTINGS, ...overrides };
 }
+
+describe('isValidMatchPattern', () => {
+  it('accepts the subset of Chrome match patterns from ADR 0023', () => {
+    expect(isValidMatchPattern('*://*.example.com/*')).toBe(true);
+    expect(isValidMatchPattern('http://localhost:3000/*')).toBe(true);
+    expect(isValidMatchPattern('https://github.com/*/*/blob/*')).toBe(true);
+  });
+
+  it('rejects what Chrome rejects and what the content script never runs on', () => {
+    expect(isValidMatchPattern('not-a-pattern')).toBe(false);
+    expect(isValidMatchPattern('https://example.com')).toBe(false);
+    expect(isValidMatchPattern('https://*example.com/*')).toBe(false);
+    expect(isValidMatchPattern('file:///Users/vinta/*')).toBe(false);
+    expect(isValidMatchPattern('<all_urls>')).toBe(false);
+    expect(isValidMatchPattern('https://www.google.com/search?*')).toBe(false);
+  });
+});
 
 describe('isValidUrl', () => {
   it('accepts http and https urls', () => {
@@ -110,5 +127,26 @@ describe('shouldAutoSpace', () => {
     const current = makeSettings({ filter_mode: 'whitelist', whitelist: ['https://example.com/*'] });
     expect(shouldAutoSpace(current, 'https://example.com/foo')).toBe(true);
     expect(shouldAutoSpace(current, 'https://other.com/')).toBe(false);
+  });
+
+  it('reads `*.host` as the host and every subdomain, as Chrome does', () => {
+    const current = makeSettings({ blacklist: ['*://*.example.com/*'] });
+    expect(shouldAutoSpace(current, 'https://example.com/')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://www.example.com/')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://example.com.evil.net/')).toBe(true);
+  });
+
+  it('matches any port unless the pattern names one, as Chrome does', () => {
+    const current = makeSettings({ blacklist: ['http://localhost/*', 'https://example.com:8443/*'] });
+    expect(shouldAutoSpace(current, 'http://localhost:3000/app')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://example.com:8443/')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://example.com/')).toBe(true);
+  });
+
+  it('reads every path character except `*` literally', () => {
+    const current = makeSettings({ blacklist: ['https://en.wikipedia.org/wiki/C++*', 'https://en.wikipedia.org/wiki/Python_(programming_language)'] });
+    expect(shouldAutoSpace(current, 'https://en.wikipedia.org/wiki/C++')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://en.wikipedia.org/wiki/Python_(programming_language)')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://en.wikipedia.org/wiki/Python')).toBe(true);
   });
 });

--- a/tests/extension/urls.test.ts
+++ b/tests/extension/urls.test.ts
@@ -11,6 +11,7 @@ describe('isValidMatchPattern', () => {
     expect(isValidMatchPattern('*://*.example.com/*')).toBe(true);
     expect(isValidMatchPattern('http://localhost:3000/*')).toBe(true);
     expect(isValidMatchPattern('https://github.com/*/*/blob/*')).toBe(true);
+    expect(isValidMatchPattern('https://www.google.com/search?*')).toBe(true);
   });
 
   it('rejects what Chrome rejects and what the content script never runs on', () => {
@@ -19,7 +20,6 @@ describe('isValidMatchPattern', () => {
     expect(isValidMatchPattern('https://*example.com/*')).toBe(false);
     expect(isValidMatchPattern('file:///Users/vinta/*')).toBe(false);
     expect(isValidMatchPattern('<all_urls>')).toBe(false);
-    expect(isValidMatchPattern('https://www.google.com/search?*')).toBe(false);
   });
 });
 
@@ -141,6 +141,13 @@ describe('shouldAutoSpace', () => {
     expect(shouldAutoSpace(current, 'http://localhost:3000/app')).toBe(false);
     expect(shouldAutoSpace(current, 'https://example.com:8443/')).toBe(false);
     expect(shouldAutoSpace(current, 'https://example.com/')).toBe(true);
+  });
+
+  it('matches the query part when the pattern has one, and a missing query too', () => {
+    const current = makeSettings({ blacklist: ['https://www.google.com/search?*'] });
+    expect(shouldAutoSpace(current, 'https://www.google.com/search?q=pangu')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://www.google.com/search')).toBe(false);
+    expect(shouldAutoSpace(current, 'https://www.google.com/maps?q=pangu')).toBe(true);
   });
 
   it('reads every path character except `*` literally', () => {


### PR DESCRIPTION
Saved Chrome match patterns could miss base domains and custom ports when passed directly to `URLPattern`. URL filters now translate the supported syntax before validation and matching, including query patterns and literal path characters. The branch also adds regression tests, clarifies filter comments, records the matching rules and query limitation in ADR 0023, and shortens the ADR 0022 filename and title.
